### PR TITLE
Add Snapshot functionality

### DIFF
--- a/config/schema/wmcontent.schema.yml
+++ b/config/schema/wmcontent.schema.yml
@@ -41,3 +41,6 @@ wmcontent.wmcontent_container.*:
     show_alignment_column:
       type: boolean
       label: 'Show alignment column'
+    snapshots_enabled:
+      type: boolean
+      label: 'Enable snapshots'

--- a/js/snapshot-copy-to-clipboard.js
+++ b/js/snapshot-copy-to-clipboard.js
@@ -1,0 +1,23 @@
+Drupal.behaviors.wmcontent_snapshot_copy_to_clipboard = {
+    attach: function () {
+        const textarea = document.querySelector('.wmcontent-snapshot-export-to-clipboard--blob');
+        const button = document.querySelector('.wmcontent-snapshot-export-to-clipboard--button');
+        const message = document.querySelector('.wmcontent-snapshot-export-to-clipboard--msg');
+
+        if (
+            !textarea || !button || !message
+        ) {
+            return;
+        }
+
+        button.addEventListener('click', (e) => {
+            e.preventDefault();
+
+            textarea.select();
+            document.execCommand('copy');
+
+            message.classList.remove('hidden');
+            return false;
+        });
+    }
+};

--- a/src/Access/WmContentContainerSnapshotAccessCheck.php
+++ b/src/Access/WmContentContainerSnapshotAccessCheck.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\wmcontent\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\wmcontent\WmContentContainerInterface;
+
+class WmContentContainerSnapshotAccessCheck implements AccessInterface
+{
+    public function access(RouteMatchInterface $routeMatch, WmContentContainerInterface $container): AccessResultInterface
+    {
+        return AccessResult::allowedIf($container->hasSnapshotsEnabled());
+    }
+}

--- a/src/Annotation/SnapshotBuilder.php
+++ b/src/Annotation/SnapshotBuilder.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\wmcontent\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * @Annotation
+ */
+class SnapshotBuilder extends Plugin
+{
+    /** @var string */
+    public $entity_type;
+    /** @var string */
+    public $bundle;
+
+    public function getId()
+    {
+        foreach (['entity_type', 'entity_type'] as $param) {
+            if (empty($this->definition[$param])) {
+                throw new \RuntimeException(sprintf(
+                    'The "%s" annotation parameter is required in %s',
+                    $param,
+                    static::class
+                ));
+            }
+        }
+
+        return implode('.', [
+            $this->definition['entity_type'],
+            $this->definition['bundle'],
+        ]);
+    }
+}

--- a/src/Common/DenormalizationResult.php
+++ b/src/Common/DenormalizationResult.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\wmcontent\Common;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\wmcontent\Service\Snapshot\SnapshotBuilderBase;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class DenormalizationResult
+{
+    /** @var \Drupal\Core\Entity\EntityInterface */
+    protected $entity;
+    /** @var \Drupal\wmcontent\Service\Snapshot\SnapshotBuilderBase */
+    protected $builder;
+
+    public function __construct(EntityInterface $entity, SnapshotBuilderBase $builder)
+    {
+        $this->entity = $entity;
+        $this->builder = $builder;
+    }
+
+    public function getEntity(): EntityInterface
+    {
+        return $this->entity;
+    }
+
+    public function getViolations(): ConstraintViolationListInterface
+    {
+        return $this->builder->getViolations();
+    }
+}

--- a/src/Controller/SnapshotOverviewController.php
+++ b/src/Controller/SnapshotOverviewController.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Drupal\wmcontent\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\EventSubscriber\MainContentViewSubscriber;
+use Drupal\Core\Form\FormBuilder;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\wmcontent\Entity\Snapshot;
+use Drupal\wmcontent\Form\Snapshot\SnapshotCreateForm;
+use Drupal\wmcontent\Form\Snapshot\SnapshotFormBase;
+use Drupal\wmcontent\Form\Snapshot\SnapshotImportForm;
+use Drupal\wmcontent\Form\Snapshot\SnapshotRestoreForm;
+use Drupal\wmcontent\Service\Snapshot\SnapshotListBuilderInterface;
+use Drupal\wmcontent\WmContentContainerInterface;
+use Drupal\wmcontent\WmContentManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class SnapshotOverviewController implements ContainerInjectionInterface
+{
+    use StringTranslationTrait;
+
+    /** @var EntityTypeBundleInfoInterface */
+    protected $entityTypeBundleInfo;
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+    /** @var \Drupal\Core\Form\FormBuilderInterface */
+    protected $formBuilder;
+    /** @var MessengerInterface */
+    protected $messenger;
+    /** @var AccountProxyInterface */
+    protected $currentUser;
+    /** @var WmContentManager */
+    protected $wmContentManager;
+    /** @var \Drupal\wmcontent\Service\Snapshot\SnapshotService */
+    protected $snapshotService;
+
+    public static function create(ContainerInterface $container)
+    {
+        $instance = new static;
+        $instance->entityTypeBundleInfo = $container->get('entity_type.bundle.info');
+        $instance->entityTypeManager = $container->get('entity_type.manager');
+        $instance->formBuilder = $container->get('form_builder');
+        $instance->messenger = $container->get('messenger');
+        $instance->currentUser = $container->get('current_user');
+        $instance->wmContentManager = $container->get('wmcontent.manager');
+        $instance->snapshotService = $container->get('wmcontent.snapshot');
+
+        return $instance;
+    }
+
+    public function overview(WmContentContainerInterface $container, ContentEntityInterface $host)
+    {
+        $listBuilder = $this->entityTypeManager->getListBuilder('wmcontent_snapshot');
+        if ($listBuilder instanceof SnapshotListBuilderInterface) {
+            $listBuilder->setContainer($container);
+            $listBuilder->setHost($host);
+        }
+        return $listBuilder->render();
+    }
+
+    public function overviewTitle(WmContentContainerInterface $container, ContentEntityInterface $host)
+    {
+        $bundleInfo = $this->entityTypeBundleInfo->getAllBundleInfo();
+        $type = $bundleInfo[$host->getEntityTypeId()][$host->bundle()]['label'];
+
+        return $this->t(
+            'Snapshots of %type %host',
+            [
+                '%type' => $type,
+                '%host' => $host->label(),
+            ]
+        );
+    }
+
+    public function createSnapshot(Request $request, WmContentContainerInterface $container, ContentEntityInterface $host)
+    {
+        $form = $this->formBuilder->getForm(
+            SnapshotCreateForm::class,
+            $container,
+            $host
+        );
+        return $form;
+    }
+
+    public function createTitle(WmContentContainerInterface $container, ContentEntityInterface $host)
+    {
+        $bundleInfo = $this->entityTypeBundleInfo->getAllBundleInfo();
+        $type = $bundleInfo[$host->getEntityTypeId()][$host->bundle()]['label'];
+
+        return $this->t(
+            'Create new snapshot of %type %host',
+            [
+                '%type' => $type,
+                '%host' => $host->label(),
+            ]
+        );
+    }
+
+    public function import(Request $request, WmContentContainerInterface $container, ContentEntityInterface $host)
+    {
+        return $this->formBuilder->getForm(
+            SnapshotImportForm::class,
+            $container,
+            $host
+        );
+    }
+
+    public function importTitle(WmContentContainerInterface $container, ContentEntityInterface $host)
+    {
+        $bundleInfo = $this->entityTypeBundleInfo->getAllBundleInfo();
+        $type = $bundleInfo[$host->getEntityTypeId()][$host->bundle()]['label'];
+
+        return $this->t(
+            'Import existing snapshot to %type %host',
+            [
+                '%type' => $type,
+                '%host' => $host->label(),
+            ]
+        );
+    }
+
+    public function restore(Request $request, WmContentContainerInterface $container, ContentEntityInterface $host, Snapshot $snapshot)
+    {
+        $form = $this->formBuilder->getForm(
+            SnapshotRestoreForm::class,
+            $container,
+            $host,
+            $snapshot
+        );
+        return $form;
+    }
+
+    public function export(Request $request, WmContentContainerInterface $container, ContentEntityInterface $host, Snapshot $snapshot)
+    {
+        $form = [];
+
+        $form['export'] = [
+            '#type' => 'container',
+            '#attached' => [
+                'library' => [
+                    'wmcontent/snapshot_copy_to_clipboard'
+                ],
+            ],
+        ];
+        $form['export']['blob'] = [
+            '#type' => 'textarea',
+            '#value' => $this->snapshotService->export(
+                $snapshot
+            ),
+            '#attributes' => [
+                'readonly' => 'readonly',
+                'class' => [
+                    'wmcontent-snapshot-export-to-clipboard--blob'
+                ],
+            ],
+        ];
+        $form['export']['copy_msg'] = [
+            '#theme' => 'status_messages',
+            '#message_list' => [
+                'status' => [
+                    'Copied to clipboard',
+                ],
+            ],
+            '#status_headings' => [
+                'status' => t('Status message'),
+                'error' => t('Error message'),
+                'warning' => t('Warning message'),
+            ],
+            '#attributes' => [
+                'class' => [
+                    'hidden',
+                    'wmcontent-snapshot-export-to-clipboard--msg',
+                ],
+            ],
+        ];
+        $form['export']['copy'] = [
+            '#type' => 'link',
+            '#url' => Url::fromUserInput('/'),
+            '#title' => 'Copy to clipboard',
+            '#attributes' => [
+                'class' => [
+                    'button',
+                    'wmcontent-snapshot-export-to-clipboard--button'
+                ],
+            ],
+        ];
+
+        $form['export']['cancel'] = [
+            '#type' => 'link',
+            '#url' => Url::fromRoute(
+                "entity.{$host->getEntityTypeId()}.wmcontent_snapshot.overview",
+                [
+                    $host->getEntityTypeId() => $host->id(),
+                    'container' => $container->id(),
+                ]
+            ),
+            '#title' => 'Back',
+            '#attributes' => [
+                'class' => ['use-ajax'],
+                'data-dialog-type' => 'modal',
+                'data-dialog-options' => json_encode(
+                    SnapshotFormBase::MODAL_DIALOG_OPTIONS,
+                    JSON_THROW_ON_ERROR
+                ),
+            ],
+        ];
+        return $form;
+    }
+
+    public function exportTitle(WmContentContainerInterface $container, ContentEntityInterface $host, Snapshot $snapshot)
+    {
+        $bundleInfo = $this->entityTypeBundleInfo->getAllBundleInfo();
+        $type = $bundleInfo[$host->getEntityTypeId()][$host->bundle()]['label'];
+
+        return $this->t(
+            'Export snapshot code of %snapshot_title (%snapshot_date)',
+            [
+                '%snapshot_title' => $snapshot->label(),
+                '%snapshot_date' => date('d/m/Y H:i', $snapshot->getCreatedTime()),
+                '%type' => $type,
+                '%host' => $host->label(),
+            ]
+        );
+    }
+
+    public function restoreTitle(WmContentContainerInterface $container, ContentEntityInterface $host, Snapshot $snapshot)
+    {
+        $bundleInfo = $this->entityTypeBundleInfo->getAllBundleInfo();
+        $type = $bundleInfo[$host->getEntityTypeId()][$host->bundle()]['label'];
+
+        return $this->t(
+            'Restore snapshot of %snapshot_date to %type %host',
+            [
+                '%snapshot_title' => $snapshot->label(),
+                '%snapshot_date' => date('d/m/Y H:i', $snapshot->getCreatedTime()),
+                '%type' => $type,
+                '%host' => $host->label(),
+            ]
+        );
+    }
+
+    public function delete(WmContentContainerInterface $container, ContentEntityInterface $child, ContentEntityInterface $host, Snapshot $snapshot)
+    {
+        $snapshot->delete();
+
+        $this->messenger->addStatus(
+            $this->t(
+                'Snapshot has been deleted.'
+            )
+        );
+
+        return new RedirectResponse(
+            Url::fromRoute(
+                'entity.' . $container->getHostEntityType() . '.wmcontent_snapshot_overview',
+                [
+                    $container->getHostEntityType() => $host->id(),
+                    'container' => $container->id(),
+                ]
+            )->toString()
+        );
+    }
+}

--- a/src/Entity/Snapshot.php
+++ b/src/Entity/Snapshot.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Drupal\wmcontent\Entity;
+
+use Drupal\Core\Entity\Annotation\ContentEntityType;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\user\UserInterface;
+use Drupal\wmcontent\Entity\Traits\BaseFieldTrait;
+use Drupal\wmcontent\WmContentContainerInterface;
+
+/**
+ * @ContentEntityType(
+ *   id = "wmcontent_snapshot",
+ *   label = @Translation("WmContent Snapshot"),
+ *   handlers = {
+ *     "list_builder" = "Drupal\wmcontent\Service\Snapshot\SnapshotListBuilder",
+ *     "form" = {
+ *       "default" = "Drupal\Core\Entity\ContentEntityForm",
+ *       "add" = "Drupal\Core\Entity\ContentEntityForm",
+ *       "edit" = "\Drupal\wmcontent\Form\Snapshot\SnapshotEntityForm",
+ *       "delete" = "Drupal\Core\Entity\ContentEntityDeleteForm",
+ *     },
+ *     "route_provider" = {
+ *       "html" = "Drupal\wmcontent\Service\Snapshot\HtmlRouteProvider",
+ *     },
+ *     "access" = "Drupal\Core\Entity\EntityAccessControlHandler",
+ *   },
+ *   base_table = "wmcontent_snapshot",
+ *   translatable = FALSE,
+ *   admin_permission = "administer wmcontent",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "title",
+ *     "uuid" = "uuid",
+ *     "langcode" = "langcode",
+ *   },
+ *   links = {
+ *     "add-form" = "/admin/wmcontent/snapshot/add",
+ *     "edit-form" = "/admin/wmcontent/snapshot/{wmcontent_snapshot}/edit",
+ *     "delete-form" = "/admin/wmcontent/snapshot/{wmcontent_snapshot}/delete",
+ *     "collection" = "/admin/wmcontent/snapshot",
+ *   },
+ *   field_ui_base_route = "entity.wmcontent_snapshot.collection"
+ * )
+ */
+class Snapshot extends ContentEntityBase
+{
+    use BaseFieldTrait;
+
+    public function label(): string
+    {
+        return $this->getTitle();
+    }
+
+    public function getTitle(): string
+    {
+        return (string) $this->get('title')->value;
+    }
+
+    public function getComment(): string
+    {
+        return (string) $this->get('comment')->value;
+    }
+
+    public function getOwner(): ?UserInterface
+    {
+        return $this->get('user_id')->entity;
+    }
+
+    public function isActive(): bool
+    {
+        return (bool) $this->get('active')->value;
+    }
+
+    public function getContainer(): ?WmContentContainerInterface
+    {
+        return $this->get('wmcontent_container')->entity;
+    }
+
+    public function getHost(): ?EntityInterface
+    {
+        $entityType = (string) $this->get('source_entity_type')->value;
+        $entityId = (string) $this->get('source_entity_type')->value;
+
+        if (empty($entityType) || empty($entityId)) {
+            return null;
+        }
+
+        return $this->entityTypeManager()
+            ->getStorage($entityType)
+            ->load($entityId);
+    }
+
+    public static function baseFieldDefinitions(EntityTypeInterface $entityType): array
+    {
+        $fields = parent::baseFieldDefinitions($entityType);
+
+        $fields['title'] = static::getStringBaseFieldDefinition(true)
+            ->setRequired(true)
+            ->setLabel(t('Title'));
+
+        $fields['environment'] = static::getStringBaseFieldDefinition(true)
+            ->setRequired(true)
+            ->setLabel(t('Environment'))
+            ->setDisplayConfigurable('form', false);
+
+        $fields['created'] = BaseFieldDefinition::create('created')
+            ->setRequired(true)
+            ->setLabel(t('Created'))
+            ->setDisplayConfigurable('form', false);
+
+        $fields['comment'] = BaseFieldDefinition::create('string_long')
+            ->setRequired(true)
+            ->setLabel(t('Comment'))
+            ->setDisplayConfigurable('form', true)
+            ->setDisplayOptions('form', [
+                'type' => 'string_textarea',
+            ]);
+
+        $fields['blob'] = BaseFieldDefinition::create('string_long')
+            ->setRequired(true)
+            ->setLabel(t('Comment'))
+            ->setDisplayConfigurable('form', false)
+            ->setSetting('case_sensitive', true); // so it's stored as blob
+
+        $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
+            ->setRequired(true)
+            ->setLabel(t('User ID'))
+            ->setDescription(t('The ID of the associated user.'))
+            ->setSetting('target_type', 'user')
+            ->setSetting('handler', 'default')
+            ->setDisplayConfigurable('form', false);
+
+        $fields['source_entity_type'] = static::getStringBaseFieldDefinition(true)
+            ->setRequired(false) // todo: if null this snapshot can be applied to any host
+            ->setLabel(t('Source entity type'))
+            ->setDisplayConfigurable('form', false);
+
+        $fields['source_entity_id'] = static::getIntegerBaseFieldDefinition(true)
+            ->setRequired(false) // todo: if null this snapshot can be applied to any host
+            ->setLabel(t('Source entity id'))
+            ->setDisplayConfigurable('form', false);
+
+        $fields['wmcontent_container'] = BaseFieldDefinition::create('entity_reference')
+            ->setRequired(false) // todo: if null this snapshot can be applied to any container
+            ->setSetting('target_type', 'wmcontent_container')
+            ->setSetting('handler', 'default')
+            ->setDisplayConfigurable('form', false);
+
+        $fields['active'] = BaseFieldDefinition::create('boolean')
+            ->setLabel(t('active'))
+            ->setDisplayConfigurable('form', false);
+
+        return $fields;
+    }
+
+    public function getCreatedTime(): int
+    {
+        return (int) $this->get('created')->value;
+    }
+
+    public function getBlob(): array
+    {
+        $blob = (string) $this->get('blob')->value;
+        if (empty($blob)) {
+            return [];
+        }
+        return json_decode(
+            $blob,
+            true,
+            512, // depth - default value
+            JSON_THROW_ON_ERROR
+        );
+    }
+
+    public function getEnvironment(): string
+    {
+        return (string) $this->get('environment')->value;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'title' => $this->getTitle(),
+            'comment' => $this->getComment(),
+            'environment' => $this->getEnvironment(),
+            'created' => $this->getCreatedTime(),
+            'blob' => $this->getBlob(),
+            'user_id' => $this->getOwner()
+                ? $this->getOwner()->id()
+                : 0,
+            'source_entity_type' => $this->get('source_entity_type')->value,
+            'source_entity_id' => $this->get('source_entity_id')->value,
+            'wmcontent_container' => $this->getContainer()
+                ? $this->getContainer()->id()
+                : null,
+            'active' => $this->isActive(),
+        ];
+    }
+
+    public static function fromArray(array $data, string $langcode): Snapshot
+    {
+        /** @var static $snapshot */
+        $snapshot = static::create([
+            'langcode' => $langcode,
+        ]);
+
+        $snapshot->set('title', $data['title'] ?? '');
+        $snapshot->set('comment', $data['comment'] ?? '');
+        $snapshot->set('environment', $data['environment'] ?? '');
+        if (!empty($data['created'])) {
+            $snapshot->set('created', $data['created']);
+        }
+        $snapshot->set('wmcontent_container', $data['wmcontent_container'] ?? null);
+        $snapshot->set('user_id', $data['user_id'] ?? null);
+        $snapshot->set('source_entity_type', $data['source_entity_type'] ?? '');
+        $snapshot->set('source_entity_id', $data['source_entity_id'] ?? '');
+        $snapshot->set('active', 0);
+        $snapshot->set('blob', json_encode(
+            $data['blob'],
+            JSON_THROW_ON_ERROR
+        ));
+
+        return $snapshot;
+    }
+
+    public function setHost(EntityInterface $host)
+    {
+        $this->set('source_entity_type', $host->getEntityTypeId());
+        $this->set('source_entity_id', $host->id());
+        return $this;
+    }
+
+    public function setContainer(WmContentContainerInterface $container)
+    {
+        $this->set('wmcontent_container', $container->id());
+        return $this;
+    }
+}

--- a/src/Entity/SnapshotLog.php
+++ b/src/Entity/SnapshotLog.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\wmcontent\Entity;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Entity\Annotation\ContentEntityType;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\user\UserInterface;
+use Drupal\wmcontent\Entity\Traits\BaseFieldTrait;
+
+/**
+ * @ContentEntityType(
+ *   id = "wmcontent_snapshot_log",
+ *   label = @Translation("WmContent Snapshot log"),
+ *   handlers = {
+ *     "list_builder" = "\Drupal\Core\Entity\EntityListBuilder",
+ *     "access" = "Drupal\Core\Entity\EntityAccessControlHandler",
+ *   },
+ *   base_table = "wmcontent_snapshot_log",
+ *   translatable = FALSE,
+ *   admin_permission = "administer wmcontent",
+ *   entity_keys = {
+ *     "id" = "id",
+ *   }
+ * )
+ */
+class SnapshotLog extends ContentEntityBase
+{
+    use BaseFieldTrait;
+
+    public function label()
+    {
+        return Unicode::truncate(
+            $this->getComment(),
+            75,
+            false,
+            true
+        );
+    }
+
+    public function getComment()
+    {
+        return (string) $this->get('comment')->value;
+    }
+
+    public function getOwner(): ?UserInterface
+    {
+        return $this->get('user_id')->entity;
+    }
+
+    public function getSnapshot(): ?Snapshot
+    {
+        return $this->get('snapshot')->entity;
+    }
+
+    public function getHost(): ?EntityInterface
+    {
+        $entityType = (string) $this->get('source_entity_type')->value;
+        $entityId = (string) $this->get('source_entity_id')->value;
+
+        if (empty($entityType) || empty($entityId)) {
+            return null;
+        }
+
+        return $this->entityTypeManager()
+            ->getStorage($entityType)
+            ->load($entityId);
+    }
+
+    public static function baseFieldDefinitions(EntityTypeInterface $entityType)
+    {
+        $fields = parent::baseFieldDefinitions($entityType);
+
+        $fields['snapshot'] = static::getStringBaseFieldDefinition(true)
+            ->setLabel(t('Title'));
+
+        $fields['created'] = BaseFieldDefinition::create('created')
+            ->setLabel(t('Created'));
+
+        $fields['comment'] = BaseFieldDefinition::create('string_long')
+            ->setLabel(t('Comment'))
+            ->setDisplayConfigurable('form', true)
+            ->setDisplayOptions('form', [
+                'type' => 'string_textarea',
+            ]);
+
+        $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
+            ->setLabel(t('User ID'))
+            ->setDescription(t('The ID of the associated user.'))
+            ->setSetting('target_type', 'user')
+            ->setSetting('handler', 'default');
+
+        $fields['source_entity_type'] = static::getStringBaseFieldDefinition(true)
+            ->setLabel(t('Source entity type'));
+
+        $fields['source_entity_id'] = static::getIntegerBaseFieldDefinition(true)
+            ->setLabel(t('Source entity id'));
+
+        return $fields;
+    }
+}

--- a/src/Entity/Traits/BaseFieldTrait.php
+++ b/src/Entity/Traits/BaseFieldTrait.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\wmcontent\Entity\Traits;
+
+use Drupal\Core\Field\BaseFieldDefinition;
+
+trait BaseFieldTrait {
+
+    public static function getBooleanBaseFieldDefinition(bool $required): BaseFieldDefinition
+    {
+        return BaseFieldDefinition::create('boolean')
+            ->setCardinality(1)
+            ->setDisplayConfigurable('form', TRUE)
+            ->setDisplayOptions('form', [
+                'type' => 'boolean_checkbox',
+            ])
+            ->setRequired($required)
+            ->setSetting('unsigned', TRUE);
+    }
+
+    public static function getDecimalBaseFieldDefinition(bool $required): BaseFieldDefinition
+    {
+        return BaseFieldDefinition::create('decimal')
+            ->setCardinality(1)
+            ->setDisplayConfigurable('form', TRUE)
+            ->setDisplayOptions('form', [
+                'type' => 'number',
+            ])
+            ->setRequired($required)
+            ->setSettings([
+                'precision' => 10,
+                'scale' => 2,
+            ])
+            ->setStorageRequired(false);
+    }
+
+    public static function getEntityReferenceBaseFieldDefinition(bool $required, string $targetType, string $targetBundle = null): BaseFieldDefinition
+    {
+        return BaseFieldDefinition::create('entity_reference')
+            ->setCardinality(1)
+            ->setDisplayConfigurable('form', TRUE)
+            ->setDisplayOptions('form', [
+                'type' => 'entity_reference_autocomplete',
+            ])
+            ->setRequired($required)
+            ->setSettings([
+                'target_type' => $targetType,
+                'handler_settings' => [
+                    'target_bundles' => [$targetBundle],
+                ],
+            ]);
+    }
+
+    public static function getIntegerBaseFieldDefinition(bool $required): BaseFieldDefinition
+    {
+        return BaseFieldDefinition::create('integer')
+            ->setCardinality(1)
+            ->setSetting('unsigned', TRUE)
+            ->setRequired($required)
+            ->setDisplayConfigurable('form', TRUE)
+            ->setDisplayOptions('form', [
+                'type' => 'number',
+            ]);
+    }
+
+    public static function getStringBaseFieldDefinition(bool $required): BaseFieldDefinition
+    {
+        return BaseFieldDefinition::create('string')
+            ->setCardinality(1)
+            ->setSettings([
+                'max_length' => 255,
+                'text_processing' => 0,
+            ])
+            ->setRequired($required)
+            ->setDisplayConfigurable('form', TRUE)
+            ->setDisplayOptions('form', [
+                'type' => 'string_textfield',
+            ]);
+    }
+}

--- a/src/Entity/WmContentContainer.php
+++ b/src/Entity/WmContentContainer.php
@@ -44,7 +44,8 @@ use Drupal\wmcontent\WmContentContainerInterface;
  *         "hide_single_option_sizes",
  *         "hide_single_option_alignments",
  *         "show_size_column",
- *         "show_alignment_column"
+ *         "show_alignment_column",
+ *         "snapshots_enabled"
  *     }
  * )
  */
@@ -72,6 +73,8 @@ class WmContentContainer extends ConfigEntityBase implements WmContentContainerI
     public $show_size_column = true;
     /** @var bool */
     public $show_alignment_column = true;
+    /** @var bool */
+    public $snapshots_enabled = false;
 
     public function getLabel(): string
     {
@@ -138,6 +141,11 @@ class WmContentContainer extends ConfigEntityBase implements WmContentContainerI
         return $this->show_alignment_column;
     }
 
+    public function hasSnapshotsEnabled(): bool
+    {
+        return $this->snapshots_enabled;
+    }
+
     public function getConfig(): array
     {
         $config = [
@@ -152,6 +160,7 @@ class WmContentContainer extends ConfigEntityBase implements WmContentContainerI
             'hide_single_option_alignments' => $this->getHideSingleOptionAlignments(),
             'show_size_column' => $this->getShowSizeColumn(),
             'show_alignment_column' => $this->getShowAlignmentColumn(),
+            'snapshots_enabled' => $this->hasSnapshotsEnabled(),
         ];
 
         if (empty($config['host_bundles'])) {

--- a/src/Form/Snapshot/ModalAjaxProxyTrait.php
+++ b/src/Form/Snapshot/ModalAjaxProxyTrait.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Drupal\wmcontent\Form\Snapshot;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\EventSubscriber\AjaxResponseSubscriber;
+use Drupal\Core\EventSubscriber\MainContentViewSubscriber;
+use Drupal\Core\Form\FormBuilder;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+trait ModalAjaxProxyTrait
+{
+    private $modalData = [];
+
+    /**
+     * Make it possible to render any page as an ajax callback in a modal.
+     *
+     * We convert the passed Url to a modal request. Which Drupal picks up and
+     * converts to a set of AjaxCommands that will do the necessary things to render
+     * that page. This allows us to render overviews as an ajax-callback without
+     * having to build the overview in the ajax callback itself.
+     */
+    protected function doAjaxRequest(Url $url): ?AjaxResponse
+    {
+        // We add _wrapper_format=drupal_modal so Drupal knows it has to respond
+        // with an AjaxResponse. We also pass in the modalData we originally got
+        // from our client. It contains info such as which libraries are already
+        // loaded and the modal width etc.
+        // We forward that data so Drupal knows it doesn't have to add a bunch of
+        // unnecessary AddCssCommand or ReplaceCommand objects to the AjaxResponse.
+        $request = Request::create(
+            $url->mergeOptions(['query' => [
+                MainContentViewSubscriber::WRAPPER_FORMAT => 'drupal_modal',
+            ]])->toString(),
+            'POST', // Default behaviour is to always POST. /shrug
+            $this->modalData,
+            $this->getRequestObject()->cookies->all()
+        );
+
+        try {
+            $response = $this->getKernel()->handle($request, HttpKernelInterface::SUB_REQUEST, false);
+        } catch (\Exception $e) {
+            // todo: meh
+            watchdog_exception('wmcontent.modal', $e);
+        }
+
+        if (!$response instanceOf AjaxResponse || !$response->getStatusCode() === 200) {
+            return null;
+        }
+
+        // For some weird reason I can't just take the AjaxResponse as-is and
+        // return that. It causes the ajax commands to be wrapped in a
+        // <textarea>. Very weird. But a shallow clone does the trick.
+        // Todo: inspect this
+        return $this->cloneResponse($response);
+    }
+
+    protected function storeModalData(array &$form, FormStateInterface $formState): void
+    {
+        // If the current form was created with an ajax request we want to store
+        // the information related to that request ( dialogOptions and
+        // ajax_page_state ).
+        // If we decide to make a subrequest to render another page in a modal
+        // we need to pass this information along so Drupal knows which libraries
+        // are already loaded etc.
+        if (
+            $this->isAjax()
+            && !$formState->has('modal_data')
+        ) {
+            $formState->set('modal_data', $this->getModalData($formState));
+        }
+
+        if ($formState->has('modal_data')) {
+            $this->modalData = $formState->get('modal_data');
+            $form['modal_data'] = [
+                '#type' => 'hidden',
+                '#value' => json_encode($this->modalData, JSON_THROW_ON_ERROR)
+            ];
+        }
+    }
+
+    protected function getModalData(FormStateInterface $formState): array
+    {
+        if ($formState->has('modal_data')) {
+            return $formState->get('modal_data');
+        }
+
+        if (isset($formState->getUserInput()['modal_data'])) {
+            return json_decode($formState->getUserInput()['modal_data'], true, 512, JSON_THROW_ON_ERROR);
+        }
+
+        $request = $this->getRequestObject();
+        if (!$request || !$this->isModal($request)) {
+            return [];
+        }
+
+        // Only keep the necessary data
+        return array_intersect_key(
+            $request->request->all(),
+            [
+                'js' => true,
+                'dialogOptions' => true,
+                AjaxResponseSubscriber::AJAX_REQUEST_PARAMETER => true, // _drupal_ajax
+                'ajax_page_state' => true,
+            ]
+        );
+    }
+
+    protected function isAjax(): bool
+    {
+        $request = $this->getRequestObject();
+        return $request
+            && (
+                $request->query->has(FormBuilder::AJAX_FORM_REQUEST)
+                || $this->isModal($request)
+            );
+    }
+
+    private function isModal(Request $request): bool
+    {
+        return $request
+            && $request->query->get(MainContentViewSubscriber::WRAPPER_FORMAT) === 'drupal_modal';
+    }
+
+    protected function cloneResponse(AjaxResponse $response): AjaxResponse
+    {
+        $cloned = new AjaxResponse();
+
+        // Get the command-array by-reference
+        $commands = &$cloned->getCommands();
+        // And fill it with the commands of the original response
+        $commands = $response->getCommands();
+
+        // Also add the attachments of the original response
+        $cloned->setAttachments($response->getAttachments());
+
+        return $cloned;
+    }
+
+    private function getRequestObject(): ?Request
+    {
+        // sue me
+        return \Drupal::request();
+    }
+
+    private function getKernel(): HttpKernelInterface
+    {
+        // sue me
+        return \Drupal::getContainer()->get('http_kernel');
+    }
+}

--- a/src/Form/Snapshot/SnapshotCreateForm.php
+++ b/src/Form/Snapshot/SnapshotCreateForm.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Drupal\wmcontent\Form\Snapshot;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\CloseModalDialogCommand;
+use Drupal\Core\Ajax\MessageCommand;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\wmcontent\Entity\Snapshot;
+use Drupal\wmcontent\WmContentContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class SnapshotCreateForm extends SnapshotFormBase
+{
+    /** @var \Drupal\wmcontent\WmContentManagerInterface */
+    protected $contentManager;
+    /** @var \Drupal\wmcontent\Service\Snapshot\SnapshotService */
+    protected $snapshotService;
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface */
+    protected $entityTypeManager;
+
+    public static function create(ContainerInterface $container)
+    {
+        /** @var static $form */
+        $form = parent::create($container);
+        $form->contentManager = $container->get('wmcontent.manager');
+        $form->snapshotService = $container->get('wmcontent.snapshot');
+        $form->entityTypeManager = $container->get('entity_type.manager');
+
+        return $form;
+    }
+
+    public function getFormId()
+    {
+        return 'wmcontent_snapshot_create';
+    }
+
+    public function buildForm(
+        array $form,
+        FormStateInterface $form_state,
+        ?WmContentContainerInterface $contentContainer = null,
+        ?EntityInterface $host = null
+    ) {
+        if (!$host || !$contentContainer) {
+            return $form;
+        }
+        $this->container = $contentContainer;
+        $this->host = $host;
+
+        $form = parent::buildForm($form, $form_state);
+
+        $input = $form_state->getUserInput();
+
+        $form['#prefix'] = '<div id="' . $this->getFormId() . '">';
+        $form['#suffix'] = '</div>';
+
+        $form['title'] = [
+            '#type' => 'textfield',
+            '#title' => $this->t('Title'),
+            '#required' => true,
+            '#description' => $this->t('A descriptive name for this snapshot.'),
+        ];
+        $form['comment'] = [
+            '#type' => 'textarea',
+            '#title' => $this->t('Description'),
+            '#required' => true,
+            '#description' => $this->t('A good description of what\'s in this snapshot.'),
+            '#rows' => 4,
+        ];
+        $form['actions']['submit'] = $this->createSubmitButton('Submit');
+        $form['actions']['cancel'] = $this->createCancelButton('Cancel');
+
+        $form['table'] = [
+            '#type' => 'table',
+            '#header' => [
+                '',
+                'Type',
+                'Label',
+            ],
+            '#rows' => [],
+            '#empty' => $this->t('There are no content blocks yet.'),
+        ];
+
+        foreach ($this->contentManager->getContent($host, $contentContainer->getId()) as $block) {
+            $form['table']['#rows'][$block->id()] = [
+                'enabled' => [
+                    'data' => [
+                        '#type' => 'checkbox',
+                        '#name' => 'blocks[' . $block->id() . ']',
+                        '#return_value' => $block->id(),
+                        '#checked' => isset($input['blocks'])
+                            ? !empty($input['blocks'][$block->id()])
+                            : true
+                    ],
+                ],
+                'type' => [
+                    'data' => [
+                        '#markup' => $block->type->entity->label(), // is bundle
+                    ],
+                ],
+                'label' => [
+                    'data' => [
+                        '#markup' => $block->label(),
+                    ],
+                ],
+            ];
+
+            if (!$this->snapshotService->isSnapshotable($block)) {
+                $form['table']['#rows'][$block->id()]['enabled']['data']['#attributes']['disabled'] = 'disabled';
+                $form['table']['#rows'][$block->id()]['enabled']['data']['#checked'] = false;
+            }
+        }
+
+        return $form;
+    }
+
+    public function submitForm(array &$form, FormStateInterface $form_state)
+    {
+        $input = $form_state->getUserInput();
+
+        $title = $input['title'];
+        $description = $input['comment'];
+
+        $blockIds = array_keys(array_filter($input['blocks']));
+
+        $blocks = $this->entityTypeManager->getStorage(
+            $this->container->getChildEntityType()
+        )->loadMultiple($blockIds);
+
+        /** @var \Drupal\user\UserInterface $user */
+        $user = $this->entityTypeManager
+            ->getStorage('user')
+            ->load($this->currentUser()->id());
+
+        /** @var Snapshot $snapshot */
+        $snapshot = $this->snapshotService->createSnapshot(
+            $blocks,
+            $title,
+            $description,
+            $user,
+            $this->container,
+            $this->host,
+            null
+        );
+        $snapshot->save();
+
+        if (!$this->isAjax()) { // If ajax we use a MessageCommand in ::onAjax
+            $this->messenger()->addStatus('Snapshot created.');
+        }
+
+        $form_state->setRedirect(
+            "entity.{$this->host->getEntityTypeId()}.wmcontent_overview",
+            [
+                $this->host->getEntityTypeId() => $this->host->id(),
+                'container' => $this->container->id(),
+            ]
+        );
+
+        return $form;
+    }
+
+    public function onAjax(array $form, FormStateInterface $formState)
+    {
+        $response = new AjaxResponse();
+
+        $response->addCommand(
+            // We don't call $this->messageCommand() because we want to display
+            // this in the real messages div and not in the one of the modal.
+            new MessageCommand('Snapshot created.')
+        );
+        $response->addCommand(
+            new CloseModalDialogCommand()
+        );
+
+        return $response;
+    }
+}

--- a/src/Form/Snapshot/SnapshotEntityForm.php
+++ b/src/Form/Snapshot/SnapshotEntityForm.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\wmcontent\Form\Snapshot;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * @property \Drupal\wmcontent\Entity\Snapshot $entity
+ */
+class SnapshotEntityForm extends ContentEntityForm
+{
+    public function form(array $form, FormStateInterface $form_state)
+    {
+        $form = parent::form($form, $form_state);
+
+        $denyList = [
+            'blob',
+            'environment',
+            'wmcontent_container',
+            'user_id',
+            'source_entity_type',
+            'source_entity_id',
+            'active',
+        ];
+
+        foreach ($denyList as $field) {
+            if (isset($form[$field])) {
+                $form[$field]['#access'] = false;
+            }
+        }
+        return $form;
+    }
+}

--- a/src/Form/Snapshot/SnapshotFormBase.php
+++ b/src/Form/Snapshot/SnapshotFormBase.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Drupal\wmcontent\Form\Snapshot;
+
+use Drupal\Core\Ajax\MessageCommand;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+abstract class SnapshotFormBase extends FormBase
+{
+    public const MODAL_DIALOG_OPTIONS = [
+        'width' => 950,
+        'minHeight' => 400,
+    ];
+    public const MODAL_MSG_CLASS = 'modal_message_container';
+
+    use ModalAjaxProxyTrait;
+
+    /** @var \Drupal\wmcontent\WmContentContainerInterface */
+    protected $container;
+    /** @var EntityInterface */
+    protected $host;
+
+    public function buildForm(
+        array $form,
+        FormStateInterface $form_state
+    ) {
+        $this->storeModalData($form, $form_state);
+        $form['#prefix'] = '<div id="' . $this->getFormId() . '">';
+        $form['#suffix'] = '</div>';
+
+        if (!$this->isAjax()) {
+            return $form;
+        }
+
+        // In a modal Drupal doesn't load the usual blocks. So we add our own
+        static::addModalDrupalBlocks($form);
+
+        return $form;
+    }
+
+    public function ajax(array $form, FormStateInterface $form_state)
+    {
+        if (
+            !$form_state->isSubmitted()
+            || $form_state->hasAnyErrors()
+        ) {
+            return $this->onAjaxError($form, $form_state);
+        }
+
+        // In ajax calls Drupal disables formstate redirects
+        // So re-enable so we can fetch the target location
+        $form_state->disableRedirect(false);
+
+        $response = $this->onAjax($form, $form_state);
+
+        // And re-disable so Drupal doesn't freak out
+        $form_state->disableRedirect(true);
+
+        return $response;
+    }
+
+    protected function createSubmitButton(string $value): array
+    {
+        $button = [
+            '#type' => 'submit',
+            '#value' => $this->t($value),
+            '#ajax' => [
+                'callback' => '::ajax',
+                'wrapper' => $this->getFormId(),
+            ],
+        ];
+        if (!$this->isAjax()) {
+            unset($button['##ajax']);
+        }
+        return $button;
+    }
+
+    protected function createCancelButton(string $title): array
+    {
+        $button = [
+            '#type' => 'link',
+            '#url' => $this->createCancelUrl(),
+            '#title' => $this->t($title),
+            '#attributes' => [
+                'class' => ['use-ajax'],
+                'data-dialog-type' => 'modal',
+                'data-dialog-options' => json_encode(
+                    static::MODAL_DIALOG_OPTIONS,
+                    JSON_THROW_ON_ERROR
+                ),
+            ],
+        ];
+
+        if (!$this->isAjax()) {
+            unset($button['#attributes']);
+        }
+        return $button;
+    }
+
+    protected function createCancelUrl(): Url
+    {
+        return Url::fromRoute(
+            "entity.{$this->host->getEntityTypeId()}.wmcontent_snapshot.overview",
+            [
+                $this->host->getEntityTypeId() => $this->host->id(),
+                'container' => $this->container->id(),
+            ]
+        );
+    }
+
+    /**
+     * @param \Drupal\Core\Form\FormStateInterface $formState
+     * @return \Drupal\Core\Ajax\AjaxResponse|array
+     */
+    protected function onAjax(array $form, FormStateInterface $formState)
+    {
+        return $form;
+    }
+
+    /**
+     * @param \Drupal\Core\Form\FormStateInterface $formState
+     * @return \Drupal\Core\Ajax\AjaxResponse|array
+     */
+    protected function onAjaxError(array $form, FormStateInterface $formState)
+    {
+        return $form;
+    }
+
+    protected function messageCommand(string $message, string $type = 'status'): MessageCommand
+    {
+        return new MessageCommand(
+            $message,
+            sprintf('.%s', static::MODAL_MSG_CLASS),
+            [
+                'type' => $type,
+            ]
+        );
+    }
+
+    public static function addModalDrupalBlocks(array &$form): void
+    {
+        $form['#attached']['library'][] = 'core/drupal.dialog.ajax';
+        $form['#attached']['library'][] = 'core/jquery.form';
+
+        // Add a message container that we can fill with an ajax MessageCommand
+        $form['msg'] = [
+            '#type' => 'container',
+            '#attributes' => [
+                'class' => [static::MODAL_MSG_CLASS]
+            ],
+        ];
+
+        // Add the local actions block
+        $form['local_actions'] = [
+            '#theme' => 'block__local_actions_block',
+            '#configuration' => [
+                'provider' => 'wmcustom',
+            ],
+            '#plugin_id' => 'foo:bar',
+            '#base_plugin_id' => 'foo:bar', /** @see \template_preprocess_block() */
+            '#derivative_plugin_id' => 'foo:bar', /** @see \template_preprocess_block() */
+            'content' => static::getLocalActions(),
+        ];
+    }
+
+    private static function getLocalActions()
+    {
+        // sue me
+        $localActions = \Drupal::getContainer()->get('plugin.manager.menu.local_action');
+        $routeName = \Drupal::getContainer()->get('current_route_match');
+
+        if (!$localActions || !$routeName) {
+            return [];
+        }
+
+        return $localActions->getActionsForRoute($routeName->getRouteName());
+    }
+}

--- a/src/Form/Snapshot/SnapshotImportForm.php
+++ b/src/Form/Snapshot/SnapshotImportForm.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\wmcontent\Form\Snapshot;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\wmcontent\WmContentContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class SnapshotImportForm extends SnapshotFormBase
+{
+    /** @var \Drupal\wmcontent\Service\Snapshot\SnapshotService */
+    protected $snapshotService;
+
+    public static function create(ContainerInterface $container)
+    {
+        /** @var static $form */
+        $form = parent::create($container);
+        $form->snapshotService = $container->get('wmcontent.snapshot');
+
+        return $form;
+    }
+
+    public function getFormId()
+    {
+        return 'wmcontent_snapshot_import';
+    }
+
+    public function buildForm(
+        array $form,
+        FormStateInterface $form_state,
+        ?WmContentContainerInterface $contentContainer = null,
+        ?EntityInterface $host = null
+    ) {
+        if (!$host || !$contentContainer) {
+            return $form;
+        }
+        $this->container = $contentContainer;
+        $this->host = $host;
+
+        $form = parent::buildForm($form, $form_state);
+
+        $form['blob'] = [
+            '#type' => 'textarea',
+            '#title' => $this->t('Import code'),
+            '#required' => true,
+            '#rows' => 4,
+        ];
+
+        $form['actions']['submit'] = $this->createSubmitButton('Import');
+        $form['actions']['cancel'] = $this->createCancelButton('Back');
+
+        return $form;
+    }
+
+    public function validateForm(array &$form, FormStateInterface $form_state)
+    {
+        $input = $form_state->getUserInput();
+
+        try {
+            $this->snapshotService->import($input['blob']);
+        } catch (\Exception $e) {
+            $form_state->setErrorByName('blob', $e->getMessage());
+        }
+
+        return $form;
+    }
+
+    public function submitForm(array &$form, FormStateInterface $form_state)
+    {
+        $input = $form_state->getUserInput();
+
+        $snapshot = $this->snapshotService->import($input['blob']);
+        $snapshot->setHost($this->host);
+        $snapshot->setContainer($this->container);
+        $snapshot->save();
+
+        if (!$this->isAjax()) { // If it's ajax we'll show the message with a MessageCommand
+            $this->messenger()->addStatus('Imported snapshot');
+        }
+
+        $form_state->setRedirect(
+            "entity.{$this->host->getEntityTypeId()}.wmcontent_snapshot.overview",
+            [
+                $this->host->getEntityTypeId() => $this->host->id(),
+                'container' => $this->container->id(),
+            ]
+        );
+
+        return $form;
+    }
+
+    /**
+     * This is being called from the parent ::ajax handler
+     * @see \Drupal\wmcontent\Form\Snapshot\SnapshotFormBase::ajax()
+     */
+    public function onAjax(array $form, FormStateInterface $formState)
+    {
+        // We want to redirect to the snapshot overview. But because we are in
+        // a modal what we actually want to do instead is replace the modal with
+        // the snapshot overview. So we create an ajax request to the target
+        // location ( snapshot overview ) and forward the AjaxResponse back to
+        // the client.
+        $response = $this->doAjaxRequest(
+            // Redirect is set in ::submit
+            $formState->getRedirect()
+        );
+        if (!$response) {
+            return $form;
+        }
+        $response->addCommand(
+            $this->messageCommand('Snapshot imported')
+        );
+
+        return $response ?: $form;
+    }
+}

--- a/src/Form/Snapshot/SnapshotRestoreForm.php
+++ b/src/Form/Snapshot/SnapshotRestoreForm.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Drupal\wmcontent\Form\Snapshot;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\RedirectCommand;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\wmcontent\Entity\Snapshot;
+use Drupal\wmcontent\Entity\SnapshotLog;
+use Drupal\wmcontent\WmContentContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class SnapshotRestoreForm extends SnapshotFormBase
+{
+    /** @var \Drupal\wmcontent\WmContentManagerInterface */
+    protected $contentManager;
+    /** @var \Drupal\wmcontent\Service\Snapshot\SnapshotService */
+    protected $snapshotService;
+    /** @var \Drupal\Core\Database\Connection */
+    protected $db;
+
+    /** @var Snapshot */
+    private $snapshot; // private so it isn't serialized
+
+    public static function create(ContainerInterface $container)
+    {
+        /** @var static $form */
+        $form = parent::create($container);
+        $form->contentManager = $container->get('wmcontent.manager');
+        $form->snapshotService = $container->get('wmcontent.snapshot');
+        $form->db = $container->get('database');
+
+        return $form;
+    }
+
+    public function getFormId()
+    {
+        return 'wmcontent_snapshot_restore';
+    }
+
+    public function buildForm(
+        array $form,
+        FormStateInterface $form_state,
+        ?WmContentContainerInterface $contentContainer = null,
+        ?EntityInterface $host = null,
+        ?Snapshot $snapshot = null
+    ) {
+        if (!$host || !$contentContainer || !$snapshot) {
+            return $form;
+        }
+        $this->container = $contentContainer;
+        $this->host = $host;
+        $this->snapshot = $snapshot;
+
+        $form = parent::buildForm($form, $form_state);
+
+        $input = $form_state->getUserInput();
+
+        $form['snapshot_title'] = [
+            '#type' => 'textfield',
+            '#title' => $this->t('Snapshot title'),
+            '#default_value' => $snapshot->getTitle(),
+            '#attributes' => [
+                'disabled' => 'disabled',
+            ],
+        ];
+        $form['description'] = [
+            '#type' => 'textarea',
+            '#title' => $this->t('Snapshot description'),
+            '#default_value' => $snapshot->getComment(),
+            '#rows' => 4,
+            '#attributes' => [
+                'disabled' => 'disabled',
+            ],
+        ];
+
+        $form['reason'] = [
+            '#type' => 'textarea',
+            '#title' => $this->t('Reason'),
+            '#required' => false,
+            '#description' => $this->t('Please enter why you want to restore this snapshot.'),
+            '#default_value' => $input['reason'] ?? null,
+            '#rows' => 4,
+        ];
+
+        $form['append'] = [
+            '#type' => 'checkbox',
+            '#title' => $this->t('Keep existing content blocks'),
+            '#required' => false,
+            '#description' => $this->t('When checked this snapshot gets added to the existing content blocks. <br />If left unchecked the existing content blocks are replaced.'),
+            '#default_value' => $input['reason'] ?? false,
+        ];
+
+        $form['actions']['submit'] = $this->createSubmitButton('Restore snapshot');
+        $form['actions']['cancel'] = $this->createCancelButton('Back');
+
+        $form['title'] = [
+            '#markup' => '<h2>Content of snapshot:</h2>',
+        ];
+
+        $form['table'] = [
+            '#type' => 'table',
+            '#header' => [
+                'Type',
+                'Label',
+                'Message',
+            ],
+            '#rows' => [],
+            '#empty' => $this->t('There are no content blocks in this snapshot.'),
+        ];
+
+        try {
+            $blocks = $this->snapshotService->denormalize(
+                $snapshot,
+                $contentContainer,
+                $host
+            );
+        } catch (\Exception $e) {
+            if (!$this->isAjax()) {
+                $this->messenger()->addError($e->getMessage());
+            }
+            $form['table']['#empty'] = $this->t('There is an error with this snapshot: <br />@error', ['@error' => $e->getMessage()]);
+            $form['actions']['submit']['#attributes']['disabled'] = 'disabled';
+            return $form;
+        }
+
+        foreach ($blocks as $i => $denormalizationResult) {
+            $block = $denormalizationResult->getEntity();
+
+            $errors = [];
+            foreach ($denormalizationResult->getViolations() as $violation) {
+                /** @var \Symfony\Component\Validator\ConstraintViolationInterface $violation */
+                $errors[] = $violation->getMessage();
+            }
+
+            $form['table']['#rows'][$i] = [
+                'type' => [
+                    'data' => [
+                        '#markup' => $block->type->entity->label(), // is bundle
+                    ],
+                ],
+                'label' => [
+                    'data' => [
+                        '#markup' => $block->label(),
+                    ],
+                ],
+                'errors' => [
+                    'data' => [
+                        '#markup' => implode('<br />', $errors),
+                    ],
+                ],
+            ];
+
+            if ($errors) {
+                $form['table']['#rows'][$i]['#attributes']['class'][] = 'error';
+            }
+        }
+
+        return $form;
+    }
+
+    public function submitForm(array &$form, FormStateInterface $form_state)
+    {
+        $input = $form_state->getUserInput();
+
+        $blocks = $this->snapshotService->denormalize(
+            $this->snapshot,
+            $this->container,
+            $this->host
+        );
+
+        /** @var \Drupal\Core\Entity\ContentEntityInterface[] $existing */
+        $existing = $this->contentManager->getContent($this->host, $this->container->id());
+
+        $tx = $this->db->startTransaction($this->host->uuid());
+        $weight = 0;
+        foreach ($existing as $block) {
+            if (empty($input['append'])) {
+                $block->delete();
+                continue;
+            }
+            $_weight = (int) $block->get('wmcontent_weight')->value;
+            if ($weight < $_weight) {
+                $weight = $_weight;
+            }
+        }
+
+        foreach ($blocks as $denormalizationResult) {
+            $block = $denormalizationResult->getEntity();
+            $block->set('wmcontent_weight', ++$weight);
+            $block->save();
+        }
+        unset($tx);
+
+        $log = SnapshotLog::create([
+            'comment' => $input['reason'] ?? '',
+            'user_id' => $this->currentUser()->id(),
+            'snapshot' => $this->snapshot->id(),
+            'source_entity_type' => $this->host->getEntityTypeId(),
+            'source_entity_id' => $this->host->id(),
+        ]);
+
+        $log->save();
+
+        if (!$this->isAjax()) {
+            $this->messenger()->addStatus('Snapshot applied successfully.');
+        }
+
+        $form_state->setRedirect(
+            "entity.{$this->host->getEntityTypeId()}.wmcontent_overview",
+            [
+                $this->host->getEntityTypeId() => $this->host->id(),
+                'container' => $this->container->id(),
+            ]
+        );
+
+        return $form;
+    }
+
+    /**
+     * This is being called from the parent ::ajax handler
+     * @see \Drupal\wmcontent\Form\Snapshot\SnapshotFormBase::ajax()
+     */
+    public function onAjax(array $form, FormStateInterface $formState)
+    {
+        $response = new AjaxResponse();
+
+        // Redirect to the content blocks overview
+        $response->addCommand(
+            $this->messageCommand('Snapshot created. Reloading page.')
+        );
+        $response->addCommand(
+            new RedirectCommand(
+                // Redirect is set in ::submitForm
+                $formState->getRedirect()->toString()
+            )
+        );
+
+        return $response;
+    }
+}

--- a/src/Form/WmContentContainerForm.php
+++ b/src/Form/WmContentContainerForm.php
@@ -162,6 +162,12 @@ class WmContentContainerForm extends EntityForm
             '#title' => $this->t('Show the alignment column'),
         ];
 
+        $form['snapshots_enabled'] = [
+            '#type' => 'checkbox',
+            '#default_value' => $this->entity->hasSnapshotsEnabled(),
+            '#title' => $this->t('Enable snapshots'),
+        ];
+
         return parent::form($form, $form_state);
     }
 

--- a/src/Form/WmContentMasterForm.php
+++ b/src/Form/WmContentMasterForm.php
@@ -97,6 +97,8 @@ class WmContentMasterForm implements FormInterface, ContainerInjectionInterface
             $query['language_content_entity'] = $_GET['language_content_entity'];
         }
 
+        $form['#attached']['library'][] = 'core/drupal.dialog.ajax';
+
         $form['container'] = [
             '#type' => 'value',
             '#value' => $container,

--- a/src/Plugin/Derivative/WmContentSnapshotContextualLinks.php
+++ b/src/Plugin/Derivative/WmContentSnapshotContextualLinks.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\wmcontent\Plugin\Derivative;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\wmcontent\Form\Snapshot\SnapshotFormBase;
+use Drupal\wmcontent\WmContentContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class WmContentSnapshotContextualLinks extends DeriverBase implements ContainerDeriverInterface
+{
+    use StringTranslationTrait;
+
+    /** @var EntityTypeManagerInterface */
+    protected $entityTypeManager;
+
+    public function __construct(
+        EntityTypeManagerInterface $entityTypeManager
+    ) {
+        $this->entityTypeManager = $entityTypeManager;
+    }
+
+    public static function create(ContainerInterface $container, $base_plugin_id)
+    {
+        return new static(
+            $container->get('entity_type.manager')
+        );
+    }
+
+    public function getDerivativeDefinitions($base_plugin_definition)
+    {
+        $storage = $this->entityTypeManager->getStorage('wmcontent_container');
+
+        /** @var WmContentContainerInterface $container */
+        foreach ($storage->loadMultiple() as $container) {
+            $config = $container->getConfig();
+
+            $actions = [
+                'overview' => [
+                    'title' => $this->t('Snapshots'),
+                    'route_name' => 'entity.' . $config['host_entity_type'] . '.wmcontent_snapshot.overview',
+                    'appears_on' => [
+                        'entity.' . $config['host_entity_type'] . '.wmcontent_overview',
+                    ],
+                ],
+                'import' => [
+                    'title' => $this->t('Import snapshot'),
+                    'route_name' => 'entity.' . $config['host_entity_type'] . '.wmcontent_snapshot.import',
+                    'appears_on' => [
+                        'entity.' . $config['host_entity_type'] . '.wmcontent_snapshot.overview',
+                    ],
+                ],
+                'create' => [
+                    'title' => $this->t('Create snapshot'),
+                    'route_name' => 'entity.' . $config['host_entity_type'] . '.wmcontent_snapshot.create',
+                    'appears_on' => [
+                        'entity.' . $config['host_entity_type'] . '.wmcontent_snapshot.overview',
+                    ],
+                ],
+            ];
+
+            foreach ($actions as $name => $action) {
+                $key = $config['host_entity_type'] . $name;
+
+                if (empty($action['disable_ajax'])) {
+                    $action['options']['attributes'] = [
+                        'class' => ['use-ajax'],
+                        'data-dialog-type' => 'modal',
+                        'data-dialog-options' => json_encode(
+                            SnapshotFormBase::MODAL_DIALOG_OPTIONS,
+                            JSON_THROW_ON_ERROR
+                        ),
+                    ];
+                    // Todo: load core/drupal.dialog.ajax when this link is shown
+                    // $action['#attached']['library'][] = 'core/drupal.dialog.ajax';
+                }
+
+                $this->derivatives[$key] = $action;
+            }
+        }
+
+        return parent::getDerivativeDefinitions($base_plugin_definition);
+    }
+}

--- a/src/Plugin/SnapshotLocalTask.php
+++ b/src/Plugin/SnapshotLocalTask.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\tracker\Plugin\Menu;
+
+use Drupal\Core\Menu\LocalTaskDefault;
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Provides route parameters needed to link to the current snapshot tab.
+ */
+class SnapshotLocalTask extends LocalTaskDefault
+{
+    public function getRouteParameters(RouteMatchInterface $routeMatch)
+    {
+        return ['user' => $this->currentUser()->Id()];
+    }
+}

--- a/src/Routing/WmContentRouteSubscriber.php
+++ b/src/Routing/WmContentRouteSubscriber.php
@@ -5,6 +5,7 @@ namespace Drupal\wmcontent\Routing;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Drupal\Core\Routing\RoutingEvents;
+use Drupal\wmcontent\Controller\SnapshotOverviewController;
 use Drupal\wmcontent\Controller\WmContentChildController;
 use Drupal\wmcontent\Form\WmContentMasterForm;
 use Drupal\wmcontent\WmContentContainerInterface;
@@ -46,10 +47,40 @@ class WmContentRouteSubscriber extends RouteSubscriberBase
                 $collection->add($overviewRouteName, $route);
             }
 
+            $snapshotOverviewRouteName = "entity.{$hostEntityTypeId}.wmcontent_snapshot.overview";
+            if (!$collection->get($snapshotOverviewRouteName)) {
+                $route = $this->getSnapshotOverviewRoute($container, $adminRoute);
+                $collection->add($snapshotOverviewRouteName, $route);
+            }
+
             $addRouteName = "entity.{$hostEntityTypeId}.wmcontent_add";
             if (!$collection->get($addRouteName)) {
                 $route = $this->getAddRoute($container, $adminRoute);
                 $collection->add($addRouteName, $route);
+            }
+
+            $snapshotImportRouteName = "entity.{$hostEntityTypeId}.wmcontent_snapshot.import";
+            if (!$collection->get($snapshotImportRouteName)) {
+                $route = $this->getSnapshotImportRoute($container, $adminRoute);
+                $collection->add($snapshotImportRouteName, $route);
+            }
+
+            $snapshotRestoreRouteName = "entity.{$hostEntityTypeId}.wmcontent_snapshot.restore";
+            if (!$collection->get($snapshotRestoreRouteName)) {
+                $route = $this->getSnapshotRestoreRoute($container, $adminRoute);
+                $collection->add($snapshotRestoreRouteName, $route);
+            }
+
+            $snapshotExportRouteName = "entity.{$hostEntityTypeId}.wmcontent_snapshot.export";
+            if (!$collection->get($snapshotExportRouteName)) {
+                $route = $this->getSnapshotExportRoute($container, $adminRoute);
+                $collection->add($snapshotExportRouteName, $route);
+            }
+
+            $snapshotCreateRouteName = "entity.{$hostEntityTypeId}.wmcontent_snapshot.create";
+            if (!$collection->get($snapshotCreateRouteName)) {
+                $route = $this->getSnapshotCreateRoute($container, $adminRoute);
+                $collection->add($snapshotCreateRouteName, $route);
             }
 
             $editRouteName = "entity.{$hostEntityTypeId}.wmcontent_edit";
@@ -146,6 +177,152 @@ class WmContentRouteSubscriber extends RouteSubscriberBase
                     ],
                     'container' => [
                         'type' => 'entity:wmcontent_container',
+                    ],
+                ],
+                '_admin_route' => $adminRoute,
+            ]
+        );
+    }
+
+    protected function getSnapshotOverviewRoute(WmContentContainerInterface $container, bool $adminRoute): Route
+    {
+        $hostEntityTypeId = $container->getHostEntityType();
+
+        return new Route(
+            $this->getBasePath($hostEntityTypeId) . '/snapshots',
+            [
+                '_controller' => SnapshotOverviewController::class . '::overview',
+                '_title_callback' => SnapshotOverviewController::class . '::overviewTitle',
+            ],
+            [
+                '_entity_access' => $hostEntityTypeId . '.update',
+                '_wmcontent_container_snapshot_access' => $container->id(),
+            ],
+            [
+                'parameters' => [
+                    $hostEntityTypeId => [
+                        'type' => 'entity:' . $hostEntityTypeId,
+                    ],
+                    'container' => [
+                        'type' => 'entity:wmcontent_container',
+                    ],
+                ],
+                '_admin_route' => $adminRoute,
+            ]
+        );
+    }
+
+    protected function getSnapshotImportRoute(WmContentContainerInterface $container, bool $adminRoute): Route
+    {
+        $hostEntityTypeId = $container->getHostEntityType();
+
+        return new Route(
+            $this->getBasePath($hostEntityTypeId) . '/snapshots/import',
+            [
+                '_controller' => SnapshotOverviewController::class . '::import',
+                '_title_callback' => SnapshotOverviewController::class . '::importTitle',
+            ],
+            [
+                '_entity_access' => $hostEntityTypeId . '.update',
+                '_wmcontent_container_snapshot_access' => $container->id(),
+            ],
+            [
+                'parameters' => [
+                    $hostEntityTypeId => [
+                        'type' => 'entity:' . $hostEntityTypeId,
+                    ],
+                    'container' => [
+                        'type' => 'entity:wmcontent_container',
+                    ],
+                ],
+                '_admin_route' => $adminRoute,
+            ]
+        );
+    }
+
+    protected function getSnapshotRestoreRoute(WmContentContainerInterface $container, bool $adminRoute): Route
+    {
+        $hostEntityTypeId = $container->getHostEntityType();
+
+        return new Route(
+            $this->getBasePath($hostEntityTypeId) . '/snapshots/restore/{snapshot}',
+            [
+                '_controller' => SnapshotOverviewController::class . '::restore',
+                '_title_callback' => SnapshotOverviewController::class . '::restoreTitle',
+            ],
+            [
+                '_entity_access' => $hostEntityTypeId . '.update',
+                '_wmcontent_container_snapshot_access' => $container->id(),
+            ],
+            [
+                'parameters' => [
+                    $hostEntityTypeId => [
+                        'type' => 'entity:' . $hostEntityTypeId,
+                    ],
+                    'container' => [
+                        'type' => 'entity:wmcontent_container',
+                    ],
+                    'snapshot' => [
+                        'type' => 'entity:wmcontent_snapshot',
+                    ],
+                ],
+                '_admin_route' => $adminRoute,
+            ]
+        );
+    }
+
+    protected function getSnapshotCreateRoute(WmContentContainerInterface $container, bool $adminRoute): Route
+    {
+        $hostEntityTypeId = $container->getHostEntityType();
+
+        return new Route(
+            $this->getBasePath($hostEntityTypeId) . '/snapshots/create',
+            [
+                '_controller' => SnapshotOverviewController::class . '::createSnapshot', // 'create' was taken
+                '_title_callback' => SnapshotOverviewController::class . '::createTitle',
+            ],
+            [
+                '_entity_access' => $hostEntityTypeId . '.update',
+                '_wmcontent_container_snapshot_access' => $container->id(),
+            ],
+            [
+                'parameters' => [
+                    $hostEntityTypeId => [
+                        'type' => 'entity:' . $hostEntityTypeId,
+                    ],
+                    'container' => [
+                        'type' => 'entity:wmcontent_container',
+                    ],
+                ],
+                '_admin_route' => $adminRoute,
+            ]
+        );
+    }
+
+    protected function getSnapshotExportRoute(WmContentContainerInterface $container, bool $adminRoute): Route
+    {
+        $hostEntityTypeId = $container->getHostEntityType();
+
+        return new Route(
+            $this->getBasePath($hostEntityTypeId) . '/snapshots/export/{snapshot}',
+            [
+                '_controller' => SnapshotOverviewController::class . '::export',
+                '_title_callback' => SnapshotOverviewController::class . '::exportTitle',
+            ],
+            [
+                '_entity_access' => $hostEntityTypeId . '.update',
+                '_wmcontent_container_snapshot_access' => $container->id(),
+            ],
+            [
+                'parameters' => [
+                    $hostEntityTypeId => [
+                        'type' => 'entity:' . $hostEntityTypeId,
+                    ],
+                    'container' => [
+                        'type' => 'entity:wmcontent_container',
+                    ],
+                    'snapshot' => [
+                        'type' => 'entity:wmcontent_snapshot',
                     ],
                 ],
                 '_admin_route' => $adminRoute,

--- a/src/Service/Snapshot/HtmlRouteProvider.php
+++ b/src/Service/Snapshot/HtmlRouteProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\wmcontent\Service\Snapshot;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\Routing\AdminHtmlRouteProvider;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class HtmlRouteProvider extends AdminHtmlRouteProvider
+{
+    public function getRoutes(EntityTypeInterface $entityType): RouteCollection
+    {
+        $routes = parent::getRoutes($entityType);
+        $routes->remove('entity.wmcontent_snapshot.canonical');
+
+        $collection = $routes->get('entity.wmcontent_snapshot.collection');
+        if ($collection) {
+            $collection->setDefault('_title', '@label');
+        }
+
+        $routes->add(
+            'entity.wmcontent_snapshot.export',
+            new Route(
+                '/admin/wmcontent/snapshot/{wmcontent_snapshot}/edit',
+                [],
+                [
+                    '_permission' => 'administer wmcontent',
+                ],
+            )
+        );
+
+        return $routes;
+    }
+}

--- a/src/Service/Snapshot/SnapshotBuilderBase.php
+++ b/src/Service/Snapshot/SnapshotBuilderBase.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\wmcontent\Service\Snapshot;
+
+use Drupal\Core\Entity\EntityInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+abstract class SnapshotBuilderBase
+{
+    public const VERSION = '2020/07/08 13:37';
+
+    /** @var ConstraintViolationListInterface */
+    protected $violations;
+
+    abstract public function normalize(EntityInterface $block): array;
+
+    abstract public function denormalize(array $data, string $langcode): EntityInterface;
+
+    public function version(): \DateTime
+    {
+        if (static::VERSION === self::VERSION) {
+            throw new \RuntimeException(sprintf(
+                'The VERSION of "%s" is still the default value. Please update it.',
+                static::class
+            ));
+        }
+        return (new \DateTime(static::VERSION));
+    }
+
+    public function getViolations(): ConstraintViolationListInterface
+    {
+        if (!isset($this->violations)) {
+            $this->violations = new ConstraintViolationList([]);
+        }
+
+        return $this->violations;
+    }
+
+    public function getMetadata(EntityInterface $block): array
+    {
+        return [];
+    }
+}

--- a/src/Service/Snapshot/SnapshotBuilderFactory.php
+++ b/src/Service/Snapshot/SnapshotBuilderFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\wmcontent\Service\Snapshot;
+
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+
+class SnapshotBuilderFactory
+{
+    /** @var \Drupal\wmcontent\Service\Snapshot\SnapshotPluginManager */
+    protected $pluginManager;
+    /** @var \Drupal\Core\DependencyInjection\ClassResolverInterface */
+    protected $classResolver;
+
+    public function __construct(
+        SnapshotPluginManager $pluginManager,
+        ClassResolverInterface $classResolver
+    ) {
+        $this->pluginManager = $pluginManager;
+        $this->classResolver = $classResolver;
+    }
+
+    public function getSnapshotBuilder(string $entityTypeId, string $bundle): ?SnapshotBuilderBase
+    {
+        try {
+            $id = implode('.', [$entityTypeId, $bundle]);
+            $definition = $this->pluginManager->getDefinition($id);
+        } catch (PluginNotFoundException $e) {
+            return null;
+        }
+
+        $builder = $this->classResolver->getInstanceFromDefinition($definition['class']);
+        if (!$builder instanceof SnapshotBuilderBase) {
+            throw new \RuntimeException(sprintf(
+                'Builder "%s" is not an instance of "%s" but "%s"',
+                $definition['class'],
+                SnapshotBuilderBase::class,
+                get_class($builder)
+            ));
+        }
+
+        return $builder;
+    }
+}

--- a/src/Service/Snapshot/SnapshotListBuilder.php
+++ b/src/Service/Snapshot/SnapshotListBuilder.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\wmcontent\Service\Snapshot;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Link;
+use Drupal\wmcontent\Form\Snapshot\ModalAjaxProxyTrait;
+use Drupal\wmcontent\Form\Snapshot\SnapshotFormBase;
+use Drupal\wmcontent\WmContentContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class SnapshotListBuilder extends EntityListBuilder implements SnapshotListBuilderInterface
+{
+    use ModalAjaxProxyTrait;
+
+    /** @var \Drupal\Core\Language\LanguageManagerInterface */
+    protected $languageManager;
+    /** @var \Drupal\Core\Form\FormBuilderInterface */
+    protected $formBuilder;
+
+    /** @var WmContentContainerInterface|null */
+    protected $contentContainer;
+    /** @var EntityInterface|null */
+    protected $host;
+
+    protected $limit = 10;
+
+    public static function createInstance(ContainerInterface $container, EntityTypeInterface $entityType)
+    {
+        /** @var static $listBuilder */
+        $listBuilder = parent::createInstance($container, $entityType);
+        $listBuilder->languageManager = $container->get('language_manager');
+        $listBuilder->formBuilder = $container->get('form_builder');
+        return $listBuilder;
+    }
+
+    public function setContainer(?WmContentContainerInterface $container): void
+    {
+        $this->contentContainer = $container;
+    }
+
+    public function setHost(?EntityInterface $host): void
+    {
+        $this->host = $host;
+    }
+
+    protected function getEntityIds()
+    {
+        $q = $this->getStorage()->getQuery();
+
+        $q->condition('langcode', $this->getLangcode());
+
+        if ($this->contentContainer) {
+            $q->condition('wmcontent_container', $this->contentContainer->id());
+        }
+
+        if ($this->host) {
+            $q->condition($or = $q->orConditionGroup());
+
+            // Any snapshot without host ( for example a template )
+            $or->condition(
+                $q->andConditionGroup()
+                    ->notExists('source_entity_type')
+                    ->notExists('source_entity_id')
+            );
+            // Any snapshot of this host
+            $or->condition(
+                $q->andConditionGroup()
+                    ->condition('source_entity_type', $this->host->getEntityTypeId())
+                    ->condition('source_entity_id', $this->host->id())
+            );
+        }
+
+        $q->sort('id', 'DESC');
+
+        if ($this->limit) {
+            $q->pager($this->limit);
+        }
+
+        return $q->execute();
+    }
+
+    public function render()
+    {
+        $overview = [];
+        if ($this->isAjax()) {
+            // In a modal Drupal doesn't load the usual blocks. So we add our own
+            SnapshotFormBase::addModalDrupalBlocks($overview);
+        }
+
+        $overview += parent::render();
+        $overview['table']['#empty'] = $this->t('There are no snapshots yet');
+        return $overview;
+    }
+
+    public function buildHeader(): array
+    {
+        $header['name'] = $this->t('Title');
+        $header['created'] = $this->t('Date created');
+        $header['user'] = $this->t('Created by');
+        $header['comment'] = $this->t('Description');
+        if (!$this->host) {
+            $header['parent'] = $this->t('Parent');
+        }
+        return $header + parent::buildHeader();
+    }
+
+    public function buildRow(EntityInterface $entity): array
+    {
+        /** @var \Drupal\wmcontent\Entity\Snapshot $entity*/
+        $row['name'] = [
+            'data' => [
+                '#markup' => $entity->label(),
+            ]
+        ];
+        $row['created'] = [
+            'data' => [
+                '#markup' => date('d/m/Y H:i', $entity->getCreatedTime()),
+            ]
+        ];
+        $row['user'] = [
+            'data' => [
+                '#markup' => $entity->getOwner()
+                    ? $entity->getOwner()->label()
+                    : '',
+            ]
+        ];
+        $row['comment'] = [
+            'data' => [
+                '#markup' => $entity->getComment(),
+            ]
+        ];
+        if (!$this->host) {
+            $row['parent'] = Link::createFromRoute(
+                $entity->getHost()->label(),
+                'entity.wmcontent_snapshot.edit_form',
+                ['wmcontent_snapshot' => $entity->id()]
+            );
+        }
+        return $row + parent::buildRow($entity);
+    }
+
+    protected function getLangcode(): string
+    {
+        return $this->host
+            ? $this->host->language()->getId()
+            : $this->languageManager->getCurrentLanguage()->getId();
+    }
+}

--- a/src/Service/Snapshot/SnapshotListBuilderInterface.php
+++ b/src/Service/Snapshot/SnapshotListBuilderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\wmcontent\Service\Snapshot;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilderInterface;
+use Drupal\wmcontent\WmContentContainerInterface;
+
+interface SnapshotListBuilderInterface extends EntityListBuilderInterface
+{
+    public function setContainer(WmContentContainerInterface $container): void;
+
+    public function setHost(EntityInterface $host): void;
+}

--- a/src/Service/Snapshot/SnapshotPluginManager.php
+++ b/src/Service/Snapshot/SnapshotPluginManager.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\wmcontent\Service\Snapshot;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\wmcontent\Annotation\SnapshotBuilder;
+
+class SnapshotPluginManager extends DefaultPluginManager
+{
+    public function __construct(
+        \Traversable $namespaces,
+        CacheBackendInterface $cacheBackend,
+        ModuleHandlerInterface $moduleHandler
+    ) {
+        parent::__construct(
+            'SnapshotBuilder',
+            $namespaces,
+            $moduleHandler,
+            SnapshotBuilderBase::class,
+            SnapshotBuilder::class
+        );
+        $this->alterInfo('wmcontent_snapshot_builders');
+        $this->setCacheBackend($cacheBackend, 'wmcontent_snapshotbuilder_info_plugins');
+    }
+
+}

--- a/src/Service/Snapshot/SnapshotService.php
+++ b/src/Service/Snapshot/SnapshotService.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Drupal\wmcontent\Service\Snapshot;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\user\UserInterface;
+use Drupal\wmcontent\Common\DenormalizationResult;
+use Drupal\wmcontent\Entity\Snapshot;
+use Drupal\wmcontent\Form\Snapshot\SnapshotFormBase;
+use Drupal\wmcontent\WmContentContainerInterface;
+
+class SnapshotService
+{
+    use StringTranslationTrait;
+
+    /** @var \Drupal\Core\Language\LanguageManagerInterface */
+    protected $languageManager;
+    /** @var \Drupal\wmcontent\Service\Snapshot\SnapshotBuilderFactory */
+    protected $snapshotBuilderFactory;
+    /** @var string */
+    protected $environment;
+    /** @var string */
+    protected $secret;
+
+    public function __construct(
+        LanguageManagerInterface $languageManager,
+        SnapshotBuilderFactory $snapshotBuilderFactory,
+        string $environment,
+        string $secret
+    ) {
+        $this->languageManager = $languageManager;
+        $this->snapshotBuilderFactory = $snapshotBuilderFactory;
+        $this->environment = $environment;
+        $this->secret = $secret;
+    }
+
+    public function isSnapshotable(EntityInterface $entity): bool
+    {
+        $builder = $this->snapshotBuilderFactory->getSnapshotBuilder(
+            $entity->getEntityTypeId(),
+            $entity->bundle()
+        );
+
+        return $builder !== null;
+    }
+
+    /**
+     * @param \Drupal\Core\Entity\EntityInterface[] $blocks
+     * @return Snapshot
+     */
+    public function createSnapshot(
+        array $blocks,
+        string $title,
+        string $description,
+        UserInterface $user,
+        WmContentContainerInterface $container,
+        ?EntityInterface $host,
+        ?string $environment
+    ): Snapshot
+    {
+        $normalized = [];
+
+        foreach ($blocks as $block) {
+            $builder = $this->getSnapshotBuilder($block);
+
+            $record = [
+                'metadata' => [
+                    'builder_version' => $builder->version()->getTimestamp(),
+                    'builder_version_human' => $builder->version()->format('d/m/Y H:i'),
+                    'entityTypeId' => $block->getEntityTypeId(),
+                    'bundle' => $block->bundle(),
+                    'entityId' => $block->id(),
+                    'uuid' => $block->uuid(),
+                ] + $builder->getMetadata($block),
+                'data' => $builder->normalize($block),
+            ];
+            unset($record['data']['id']);
+            unset($record['data']['uuid']);
+            unset($record['data']['wmcontent_parent']);
+            unset($record['data']['wmcontent_parent_type']);
+            unset($record['data']['wmcontent_container']);
+
+            $normalized[] = $record;
+        }
+
+        /** @var Snapshot $snapshot */
+        $snapshot = Snapshot::fromArray([
+            'title' => $title,
+            'comment' => $description,
+            'user_id' => $user,
+            'source_entity_type' => $host ? $host->getEntityTypeId() : null,
+            'source_entity_id' => $host ? $host->id() : null,
+            'wmcontent_container' => $container,
+            'environment' => $environment ?: $this->environment,
+            'blob' => $normalized,
+        ], $this->languageManager->getCurrentLanguage()->getId());
+
+        return $snapshot;
+    }
+
+    /**
+     * Convert array of normalized content blocks back to entities
+     *
+     * @param array $data
+     * @return DenormalizationResult[]
+     */
+    public function denormalize(
+        Snapshot $snapshot,
+        WmContentContainerInterface $container,
+        EntityInterface $host
+    ): array {
+        $denormalized = [];
+
+        foreach ($snapshot->getBlob() as $block) {
+            if (empty($block['metadata']['entityTypeId']) || empty($block['metadata']['bundle'])) {
+                throw new \RuntimeException(sprintf(
+                    'Invalid data array. Cannot denormalize because missing "entityTypeId" and/or "bundle" key'
+                ));
+            }
+            $builder = $this->getSnapshotBuilder($block['metadata']['entityTypeId'], $block['metadata']['bundle']);
+
+            $block['data']['wmcontent_container'] = [
+                [
+                    'value' => $container->id(),
+                ]
+            ];
+            $block['data']['wmcontent_parent'] = [
+                [
+                    'value' => $host->id(),
+                ]
+            ];
+            $block['data']['wmcontent_parent_type'] = [
+                [
+                    'value' => $host->getEntityTypeId(),
+                ]
+            ];
+
+            $denormalized[] = new DenormalizationResult(
+                $builder->denormalize($block['data'], $this->languageManager->getCurrentLanguage()->getId()),
+                $builder
+            );
+        }
+
+        return $denormalized;
+    }
+
+    public function getEntityOperations(Snapshot $snapshot, RouteMatchInterface $currentRouteMatch): array
+    {
+        $operations = [];
+        $container = $snapshot->getContainer();
+        if (!$container instanceof WmContentContainerInterface) {
+            return [];
+        }
+        $host = $currentRouteMatch->getParameter($container->getHostEntityType());
+        if (!$host instanceof EntityInterface) {
+            return [];
+        }
+
+        $snapshotBaseRoute = sprintf('entity.%s.wmcontent_snapshot', $host->getEntityTypeId());
+
+        $operations['restore'] = [
+            'title' => $this->t('Restore'),
+            'url' => Url::fromRoute($snapshotBaseRoute . '.restore', [
+                $host->getEntityTypeId() => $host->id(),
+                'container' => $container->id(),
+                'snapshot' => $snapshot->id(),
+            ]),
+            'attributes' => [
+                'class' => ['use-ajax'],
+                'data-dialog-type' => 'modal',
+                'data-dialog-options' => json_encode(
+                    SnapshotFormBase::MODAL_DIALOG_OPTIONS,
+                    JSON_THROW_ON_ERROR
+                ),
+            ],
+        ];
+
+        $operations['export'] = [
+            'title' => $this->t('Export code'),
+            'url' => Url::fromRoute($snapshotBaseRoute . '.export', [
+                $host->getEntityTypeId() => $host->id(),
+                'container' => $container->id(),
+                'snapshot' => $snapshot->id(),
+            ]),
+            'attributes' => [
+                'class' => ['use-ajax'],
+                'data-dialog-type' => 'modal',
+                'data-dialog-options' => json_encode(
+                    SnapshotFormBase::MODAL_DIALOG_OPTIONS,
+                    JSON_THROW_ON_ERROR
+                ),
+            ],
+        ];
+
+        return $operations;
+    }
+
+    /**
+     * @param string|EntityInterface $entityTypeId
+     * @param string|null $bundle
+     * @return \Drupal\wmcontent\Service\Snapshot\SnapshotBuilderBase
+     */
+    protected function getSnapshotBuilder($entityTypeId, ?string $bundle = null): SnapshotBuilderBase
+    {
+        if ($entityTypeId instanceof EntityInterface) {
+            $bundle = $entityTypeId->bundle();
+            $entityTypeId = $entityTypeId->getEntityTypeId();
+        }
+
+        $builder = $this->snapshotBuilderFactory->getSnapshotBuilder(
+            $entityTypeId,
+            $bundle
+        );
+
+        if (!$builder) {
+            throw new \RuntimeException(sprintf(
+                'No snapshot builder found for %s.%s',
+                $entityTypeId,
+                $bundle
+            ));
+        }
+
+        return $builder;
+    }
+
+    public function export(Snapshot $snapshot): string
+    {
+        $blob = $snapshot->toArray();
+        $blob['hmac'] = $this->hmac($blob);
+        return base64_encode(json_encode($blob, JSON_THROW_ON_ERROR));
+    }
+
+    public function import(string $data): Snapshot
+    {
+        $blob = json_decode(base64_decode($data), true, 512, JSON_THROW_ON_ERROR);
+        $hmac = $blob['hmac'] ?? '';
+        unset($blob['hmac']);
+
+        if (!hash_equals($hmac, $this->hmac($blob))) {
+            throw new \Exception('Snapshot is invalid.');
+        }
+
+        return Snapshot::fromArray($blob, $this->languageManager->getCurrentLanguage()->getId());
+    }
+
+    protected function hmac(array $blob): string
+    {
+        return hash_hmac(
+            'sha256',
+            json_encode($blob, JSON_THROW_ON_ERROR),
+            $this->secret
+        );
+    }
+}

--- a/src/WmContentContainerInterface.php
+++ b/src/WmContentContainerInterface.php
@@ -38,4 +38,6 @@ interface WmContentContainerInterface extends ConfigEntityInterface
     public function isHost(EntityInterface $host): bool;
 
     public function hasChild(EntityInterface $child): bool;
+
+    public function hasSnapshotsEnabled(): bool;
 }

--- a/wmcontent.install
+++ b/wmcontent.install
@@ -96,3 +96,24 @@ function wmcontent_update_8004()
     $config->getEditable('wmcontent.wmcontentmaster')->delete();
     $config->getEditable('wmcontent.wmcontentsettings')->delete();
 }
+
+/**
+ * Install wmcontent_snapshot entitytype
+ */
+function wmcontent_update_8005()
+{
+    \Drupal::entityTypeManager()->clearCachedDefinitions();
+
+    foreach (['wmcontent_snapshot', 'wmcontent_snapshot_log'] as $entityTypeId) {
+        $entityType = \Drupal::entityTypeManager()->getDefinition($entityTypeId);
+
+        if (!$entityType) {
+            continue;
+        }
+
+        \Drupal::entityDefinitionUpdateManager()->installEntityType($entityType);
+    }
+
+}
+
+

--- a/wmcontent.libraries.yml
+++ b/wmcontent.libraries.yml
@@ -1,0 +1,3 @@
+snapshot_copy_to_clipboard:
+    js:
+        js/snapshot-copy-to-clipboard.js: {}

--- a/wmcontent.links.action.yml
+++ b/wmcontent.links.action.yml
@@ -3,3 +3,6 @@ wmcontent.container.add_form:
     title: 'Add container'
     appears_on:
         - wmcontent.collection
+
+entity.node.wmcontent_snapshot.import:
+    deriver: 'Drupal\wmcontent\Plugin\Derivative\WmContentSnapshotContextualLinks'

--- a/wmcontent.module
+++ b/wmcontent.module
@@ -6,10 +6,12 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\EventSubscriber\MainContentViewSubscriber;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\wmcontent\Entity\Snapshot;
 use Drupal\wmcontent\Entity\WmContentContainer;
 use Drupal\wmcontent\Event\ContentBlockChangedEvent;
 use Drupal\wmcontent\Field\IndexableBaseFieldDefinition;
@@ -68,8 +70,43 @@ function wmcontent_entity_type_alter(array &$entityTypes): void
     }
 }
 
+function wmcontent_entity_operation_alter(array &$operations, EntityInterface $entity)
+{
+    foreach ($operations as &$operation) {
+        /** @var Url $url */
+        $url = $operation['url'] ?? null;
+        if (!$url) {
+            continue;
+        }
+        $queryOption = $url->getOption('query') ?: [];
+        if (empty($queryOption['destination'])) {
+            continue;
+        }
+        $uri = parse_url($queryOption['destination']);
+        if (empty($uri['query'])) {
+            continue;
+        }
+        $query = [];
+        parse_str($uri['query'], $query);
+        unset($query[MainContentViewSubscriber::WRAPPER_FORMAT]);
+        $uri['query'] = http_build_query($query);
+        if (empty($uri['query'])) {
+            unset($uri['query']);
+        }
+        $queryOption['destination'] = _wmcontent_unparse_url($uri);
+        $url->setOption('query', $queryOption);
+    }
+}
+
 function wmcontent_entity_operation(EntityInterface $entity): array
 {
+    if ($entity instanceof Snapshot) {
+        return \Drupal::getContainer()->get('wmcontent.snapshot')->getEntityOperations(
+            $entity,
+            \Drupal::getContainer()->get('current_route_match')
+        );
+    }
+
     if (!$entity instanceof ContentEntityInterface) {
         return [];
     }
@@ -461,4 +498,78 @@ function wmcontent_form_alter(array &$form, FormStateInterface $formState, strin
             }
         }
     }
+}
+
+/**
+ * Alter pagination urls to ajax urls when they are rendered in a Modal
+ */
+function wmcontent_preprocess_pager(&$variables)
+{
+    $request = \Drupal::request();
+    if (
+        !$request
+        || !isset($variables['items']['pages'])
+        || $request->query->get(MainContentViewSubscriber::WRAPPER_FORMAT) !== 'drupal_modal'
+    ) {
+        // Not a modal request or no items being rendered. So bail early
+        return;
+    }
+
+    $turnIntoModalUrl = static function (&$item) use (&$request) {
+        // Remove ?_wrapper_format=modal from the pagination urls.
+        // If they are kept in Drupal does weird things like wrapping it's ajax
+        // response with a <textarea>
+        $query = [];
+        parse_str(trim($item['href'], '?'), $query);
+        unset($query[MainContentViewSubscriber::WRAPPER_FORMAT]);
+
+        // Instead of having a relative ?page=0 we have to add the location.
+        // This is because in the browser the current location is the page
+        // the modal is triggered from.
+        // Eg if you're on /admin/content and you click on /node/5/overview
+        // that opens in a modal and contains pager links. If we'd render those
+        // pager links with '?page=0' the browser would call /admin/content?page=0
+        // instead of /node/5/overview?page=0 when clicked.
+        //
+        // So use the current request to create a non-relative url.
+        $item['href'] = Url::createFromRequest($request)
+            ->mergeOptions(['query' => $query])
+            ->toString(true)->getGeneratedUrl();
+
+        // Have the urls open in a modal.
+        /** @var \Drupal\Core\Template\Attribute $attribute */
+        $attribute = $item['attributes'];
+        $attribute->addClass('use-ajax');
+        $attribute->setAttribute('data-dialog-type', 'modal');
+        $attribute->setAttribute(
+            'data-dialog-options',
+            // Use the dialog options that were used to display the current modal
+            json_encode($request->request->get('dialogOptions', []), JSON_THROW_ON_ERROR)
+        );
+    };
+
+    foreach ($variables['items']['pages'] as &$item) {
+        $turnIntoModalUrl($item);
+    }
+    unset($item);
+
+    foreach (['first', 'previous', 'next', 'last'] as $name) {
+        if (!empty($variables['items'][$name])) {
+            $turnIntoModalUrl($variables['items'][$name]);
+        }
+    }
+}
+
+function _wmcontent_unparse_url($parsed_url)
+{
+    $scheme = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+    $host = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+    $port = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+    $user = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+    $pass = isset($parsed_url['pass']) ? ':' . $parsed_url['pass'] : '';
+    $pass = ($user || $pass) ? "$pass@" : '';
+    $path = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+    $query = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+    $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+    return $scheme . $user . $pass . $host . $port . $path . $query . $fragment;
 }

--- a/wmcontent.services.yml
+++ b/wmcontent.services.yml
@@ -1,3 +1,7 @@
+parameters:
+    wmcontent.environment: 'production'
+    wmcontent.snapshot.secret: 'changeme'
+
 services:
     wmcontent.manager:
         class: Drupal\wmcontent\WmContentManager
@@ -25,6 +29,11 @@ services:
         tags:
             - { name: access_check, applies_to: _wmcontent_container_view_access }
 
+    wmcontent.container_snapshot_access:
+        class: Drupal\wmcontent\Access\WmContentContainerSnapshotAccessCheck
+        tags:
+            - { name: access_check, applies_to: _wmcontent_container_snapshot_access }
+
     wmcontent.entity_updates:
         class: Drupal\wmcontent\EntityUpdateService
         arguments:
@@ -43,3 +52,21 @@ services:
 
     wmcontent.argument_resolver.host_entity:
         class: Drupal\wmcontent\ArgumentResolver\HostEntityResolver
+
+    plugin.manager.wmcontent.snapshot:
+        class: Drupal\wmcontent\Service\Snapshot\SnapshotPluginManager
+        parent: default_plugin_manager
+
+    wmcontent.snapshot_builder.factory:
+        class: Drupal\wmcontent\Service\Snapshot\SnapshotBuilderFactory
+        arguments:
+            - '@plugin.manager.wmcontent.snapshot'
+            - '@class_resolver'
+
+    wmcontent.snapshot:
+        class: Drupal\wmcontent\Service\Snapshot\SnapshotService
+        arguments:
+            - '@language_manager'
+            - '@wmcontent.snapshot_builder.factory'
+            - '%wmcontent.environment%'
+            - '%wmcontent.snapshot.secret%'


### PR DESCRIPTION
Make it possible to save the state of your content blocks at any given time.

With export/import

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
