### PR TITLE
Require Drupal 9.1 and PHP 8.0

### DIFF
--- a/.php_cs.php
+++ b/.php_cs.php
@@ -1,9 +1,9 @@
 <?php
 
 use Wieni\wmcodestyle\PhpCsFixer\Config\Factory;
-use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php71;
+use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php80;
 
-$config = Factory::fromRuleSet(new Php71);
+$config = Factory::fromRuleSet(new Php80);
 
 $config->getFinder()
     ->ignoreVCSIgnored(true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed 
+- Fix Event dispatching deprecations (https://www.drupal.org/node/3159012 and https://www.drupal.org/node/3154407)
 
 ## [1.3.7] - 2021-08-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Fixed 
-- Fix Event dispatching deprecations (https://www.drupal.org/node/3159012 and https://www.drupal.org/node/3154407)
+## [2.0.0] - 2021-08-24
+- Update composer requirements to Drupal 9.1 and PHP 8.0
 
 ## [1.3.7] - 2021-08-24
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ still not solved in Drupal 8 AFAWK).
 
 ## Installation
 
-This package requires PHP 7.1 and Drupal 9.1 or higher. It can be
+This package requires PHP 8.0 and Drupal 9.1 or higher. It can be
 installed using Composer:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ still not solved in Drupal 8 AFAWK).
 
 ## Installation
 
-This package requires PHP 7.1 and Drupal 8.5 or higher. It can be
+This package requires PHP 7.1 and Drupal 9.1 or higher. It can be
 installed using Composer:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "drupal/core": "^8.7.7 || ^9"
+        "drupal/core": "^9.1"
     },
     "require-dev": {
         "drupal/core-dev": "^8.5 || ^9",

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": "^8.0",
         "drupal/core": "^9.1"
     },
     "require-dev": {
-        "drupal/core-dev": "^8.5 || ^9",
+        "drupal/core-dev": "^9.1",
         "ergebnis/composer-normalize": "^2.0",
-        "wieni/wmcodestyle": "^1.3"
+        "wieni/wmcodestyle": "^1.7"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Event/ContentBlockChangedEvent.php
+++ b/src/Event/ContentBlockChangedEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\wmcontent\Event;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\wmcontent\WmContentContainerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 /**
  * Event that fires when a content block has been created/updated/deleted

--- a/src/Event/WmContentEntityLabelEvent.php
+++ b/src/Event/WmContentEntityLabelEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\wmcontent\Event;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\field\FieldConfigInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 /**
  * The Event that fires when looking for entity labels on wmcontent tabs

--- a/wmcontent.module
+++ b/wmcontent.module
@@ -153,8 +153,8 @@ function wmcontent_entity_update(EntityInterface $entity): void
 
     if ($manager->isChild($entity)) {
         $dispatcher->dispatch(
-            ContentBlockChangedEvent::NAME,
-            new ContentBlockChangedEvent($entity, $manager->getChildContainers($entity))
+            new ContentBlockChangedEvent($entity, $manager->getChildContainers($entity)),
+            ContentBlockChangedEvent::NAME
         );
     }
 }
@@ -172,8 +172,8 @@ function wmcontent_entity_insert(EntityInterface $entity): void
 
     if ($manager->isChild($entity)) {
         $dispatcher->dispatch(
-            ContentBlockChangedEvent::NAME,
-            new ContentBlockChangedEvent($entity, $manager->getChildContainers($entity))
+            new ContentBlockChangedEvent($entity, $manager->getChildContainers($entity)),
+            ContentBlockChangedEvent::NAME
         );
     }
 }
@@ -191,8 +191,8 @@ function wmcontent_entity_delete(EntityInterface $entity): void
 
     if ($manager->isChild($entity)) {
         $dispatcher->dispatch(
-            ContentBlockChangedEvent::NAME,
-            new ContentBlockChangedEvent($entity, $manager->getChildContainers($entity))
+            new ContentBlockChangedEvent($entity, $manager->getChildContainers($entity)),
+            ContentBlockChangedEvent::NAME
         );
     }
 }


### PR DESCRIPTION
Some deprecations are being thrown now and its a pain to provide a backwards compatible solution.

See https://www.drupal.org/node/3159012 and https://www.drupal.org/node/3154407

This MR will bump the composer requirement to Drupal 9.1 and PHP 8.0