### PR TITLE
#50 Remove compatibility with Drupal 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2024-09-13
+- Deleted the `2.1.0` tag (see #50)
+- Update composer requirements to Drupal 10.0 and PHP 8.1
+
 ## [2.0.0] - 2021-08-24
 - Update composer requirements to Drupal 9.1 and PHP 8.0
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ still not solved in Drupal 8 AFAWK).
 
 ## Installation
 
-This package requires PHP 8.0 and Drupal 9.1 or higher. It can be
+This package requires PHP 8.1 and Drupal 10.0 or higher. It can be
 installed using Composer:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "drupal/core": "^9.2 || ^10.0"
+        "php": "^8.1",
+        "drupal/core": "^10.0"
     },
     "require-dev": {
-        "drupal/core-dev": "^9.2 || ^10.0",
+        "drupal/core-dev": "^10.0",
         "ergebnis/composer-normalize": "^2.0",
         "wieni/wmcodestyle": "^1.7"
     },

--- a/wmcontent.info.yml
+++ b/wmcontent.info.yml
@@ -1,8 +1,8 @@
 name: wmcontent
 type: module
 description: Adds configurable entity containers to entity types (for e.g. paragraphs)
-version: 1.3.0
-core_version_requirement: ^9.2 || ^10
+version: 2.2.0
+core_version_requirement: ^10
 package: Wieni
 dependencies:
     - options


### PR DESCRIPTION
ValueResolverInterface is only available since Drupal 10.0 (Symfony 6.2)