### PR TITLE
#52 Store snapshot original language and pass it to denormalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2023-09-26
+- Add `source_langcode` field to `wmcontent_snapshot` entity type. An update hook is provided.
+- **BC**: Changed [SnapshotBuilderBase::denormalize()](https://github.com/wieni/wmcontent/blob/2.0.2/src/Service/Snapshot/SnapshotBuilderBase.php#L18) argument parameters. Read the [upgrade guide](UPGRADING.md) for more information.
+
 ## [2.0.0] - 2021-08-24
 - Update composer requirements to Drupal 9.1 and PHP 8.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,16 @@ This document describes breaking changes and how to upgrade. For a
 complete list of changes including minor and patch releases, please
 refer to the [`CHANGELOG`](CHANGELOG.md).
 
+## `2.0.2`
+
+The arguments of [SnapshotBuilderBase::denormalize()](https://github.com/wieni/wmcontent/blob/2.0.2/src/Service/Snapshot/SnapshotBuilderBase.php#L18) have changed.
+You'll need to update every class that extends `SnapshotBuilderBase`.
+
+```diff
+- public function denormalize(array $data, string $langcode): EntityInterface;
++ public function denormalize(array $data, string $sourceLangcode, string $targetLangcode): EntityInterface;
+```
+
 ## v1
 ### Type hints
 Argument and return types were added for most methods and functions, so

--- a/src/Service/Snapshot/SnapshotBuilderBase.php
+++ b/src/Service/Snapshot/SnapshotBuilderBase.php
@@ -15,7 +15,7 @@ abstract class SnapshotBuilderBase
 
     abstract public function normalize(EntityInterface $block): array;
 
-    abstract public function denormalize(array $data, string $langcode): EntityInterface;
+    abstract public function denormalize(array $data, string $sourceLangcode, string $targetLangcode): EntityInterface;
 
     public function version(): \DateTime
     {

--- a/src/Service/Snapshot/SnapshotListBuilder.php
+++ b/src/Service/Snapshot/SnapshotListBuilder.php
@@ -98,11 +98,20 @@ class SnapshotListBuilder extends EntityListBuilder implements SnapshotListBuild
             ],
         ];
         if (!$this->host) {
-            $row['parent'] = Link::createFromRoute(
-                $entity->getHost()->label(),
-                'entity.wmcontent_snapshot.edit_form',
-                ['wmcontent_snapshot' => $entity->id()]
-            );
+            $host = $entity->getHost();
+            $row['parent'] = [
+                'data' => [
+                    '#markup' => $this->t('Unknown parent'),
+                ],
+            ];
+
+            if ($host) {
+                $row['parent'] = Link::createFromRoute(
+                    $host->label(),
+                    'entity.wmcontent_snapshot.edit_form',
+                    ['wmcontent_snapshot' => $entity->id()],
+                );
+            }
         }
         return $row + parent::buildRow($entity);
     }

--- a/src/Service/Snapshot/SnapshotService.php
+++ b/src/Service/Snapshot/SnapshotService.php
@@ -90,6 +90,7 @@ class SnapshotService
             'title' => $title,
             'comment' => $description,
             'user_id' => $user,
+            'source_langcode' => $host ? $host->language()->getId() : $language->getId(),
             'source_entity_type' => $host ? $host->getEntityTypeId() : null,
             'source_entity_id' => $host ? $host->id() : null,
             'wmcontent_container' => $container,
@@ -138,7 +139,7 @@ class SnapshotService
             ];
 
             $denormalized[] = new DenormalizationResult(
-                $builder->denormalize($block['data'], $language->getId()),
+                $builder->denormalize($block['data'], $snapshot->getSourceLangcode(), $language->getId()),
                 $builder
             );
         }

--- a/wmcontent.install
+++ b/wmcontent.install
@@ -1,8 +1,35 @@
 <?php
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityLastInstalledSchemaRepositoryInterface;
 use Drupal\wmcontent\Entity\WmContentContainer;
 use Drupal\wmcontent\Field\IndexableBaseFieldDefinition;
+
+function _wmcontent_update_base_entity(string $entityTypeId, string $provider = 'wmcontent'): void
+{
+    /* @var EntityFieldManagerInterface $fieldManager */
+    $fieldManager = \Drupal::service('entity_field.manager');
+    $fieldStorageDefinitions = $fieldManager->getFieldStorageDefinitions($entityTypeId);
+    /** @var EntityLastInstalledSchemaRepositoryInterface $lastInstalledSchemaRepository */
+    $lastInstalledSchemaRepository = \Drupal::service('entity.last_installed_schema.repository');
+    $lastInstalledSchema = $lastInstalledSchemaRepository->getLastInstalledFieldStorageDefinitions($entityTypeId);
+
+    foreach (array_keys($fieldStorageDefinitions) as $field) {
+        if (isset($lastInstalledSchema[$field])) {
+            Drupal::entityDefinitionUpdateManager()->updateFieldStorageDefinition(
+                $fieldStorageDefinitions[$field]
+            );
+            continue;
+        }
+
+        Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition(
+            $field,
+            $entityTypeId,
+            $provider,
+            $fieldStorageDefinitions[$field]
+        );
+    }
+}
 
 function wmcontent_install()
 {
@@ -113,4 +140,20 @@ function wmcontent_update_8005()
 
         \Drupal::entityDefinitionUpdateManager()->installEntityType($entityType);
     }
+}
+
+/**
+ * Add 'source_langcode' to wmcontent_snapshot entity type
+ */
+function wmcontent_update_8006()
+{
+    _wmcontent_update_base_entity('wmcontent_snapshot');
+    $entityType = \Drupal::entityTypeManager()->getDefinition('wmcontent_snapshot');
+
+    // Fill the new field with the current langcode.
+    // ::setInitialValue('langcode') did not work because "Illegal initial value definition on source_langcode: The field types do not match."
+    \Drupal::database()
+        ->update($entityType->getBaseTable())
+        ->expression('source_langcode', 'langcode')
+        ->execute();
 }


### PR DESCRIPTION
## Description

See #52 for detailed information.
This PR adds a `source_langcode` to the Snapshot entity type.
And passes that value to the `SnapshotBuilder::denormalize()` method.

### Documentation

I updated the changelog and upgrade documents.
This PR contains a BreakingChange.
However, I don't think anyone is using snapshots so I'm risking my skin here.

#### Upgrade

The arguments of [SnapshotBuilderBase::denormalize()](https://github.com/wieni/wmcontent/blob/2.0.1/src/Service/Snapshot/SnapshotBuilderBase.php#L18) have changed.
You'll need to update every class that extends `SnapshotBuilderBase`.

```diff
- public function denormalize(array $data, string $langcode): EntityInterface;
+ public function denormalize(array $data, string $sourceLangcode, string $targetLangcode): EntityInterface;
```
