### PR TITLE
Fix "Oops, something went wrong. Check your browser's developer console for more details." Ajax message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2023-12-05
+- Fix Error Ajax message upon deleting a content block in Drupal 10.1
+
 ## [2.2.1] - 2023-09-26
 - Add `source_langcode` field to `wmcontent_snapshot` entity type. An update hook is provided.
 - **BC**: Changed [SnapshotBuilderBase::denormalize()](https://github.com/wieni/wmcontent/blob/2.2.1/src/Service/Snapshot/SnapshotBuilderBase.php#L18) argument parameters. Read the [upgrade guide](UPGRADING.md) for more information.

--- a/src/Form/WmContentMasterForm.php
+++ b/src/Form/WmContentMasterForm.php
@@ -304,6 +304,24 @@ class WmContentMasterForm implements FormInterface, ContainerInjectionInterface
         }
 
         if ($child->access('delete')) {
+            // Since Drupal 10.1, all delete operations are handled through ajax
+            // Drupal assumes a ConfirmFormBase is used which will be rendered
+            // in a modal now.
+            // see https://www.drupal.org/project/drupal/issues/2253257
+            // Instead, we replace the default delete url with our own where we
+            // do an immediate delete and redirect back to the current form.
+            // Ideally we _can_ replace this with some kind of ajax operation,
+            // it would greatly improve the UX. But how often does an editor
+            // make actual use of this delete button? Is it worth the effort?
+            //
+            // For now, we'll disable the ajax magic by removing the 'use-ajax'
+            // class set by Drupal.
+            if (isset($operations['delete']['attributes']['class'])) {
+                $operations['delete']['attributes']['class'] = array_diff(
+                    $operations['delete']['attributes']['class'],
+                    ['use-ajax']
+                );
+            }
             $operations['delete']['url'] = Url::fromRoute(
                 "entity.{$container->getHostEntityType()}.wmcontent_delete",
                 [


### PR DESCRIPTION
Since Drupal 10.1, all delete operations are handled through an Ajax Drupal Modal.
Drupal assumes a ConfirmForm will be rendered in that modal.

But we replace the default delete url with our own where we do an immediate delete and redirect back to the current form. 
So there is no Modal being rendered which triggers an error.

Ideally we _can_ replace this with some kind of ajax operation, it would greatly improve the UX.
But how often does an editor make actual use of this delete button? Is it worth the effort?

For now, we'll disable the ajax magic by removing the 'use-ajax' class set by Drupal.

see https://www.drupal.org/project/drupal/issues/2253257