### PR TITLE
Fix Expected a scalar value as a 2nd argument to "Symfony\Component\H…

### DIFF
--- a/wmcontent.module
+++ b/wmcontent.module
@@ -563,7 +563,7 @@ function wmcontent_preprocess_pager(&$variables)
         $attribute->setAttribute(
             'data-dialog-options',
             // Use the dialog options that were used to display the current modal
-            json_encode($request->request->get('dialogOptions', []), JSON_THROW_ON_ERROR)
+            json_encode(($request->request->all()['dialogOptions'] ?? []), JSON_THROW_ON_ERROR)
         );
     };
 


### PR DESCRIPTION
Error `Expected a scalar value as a 2nd argument to "Symfony\Component\HttpFoundation\InputBag::get()", "array" given.`

borrowed fix from https://www.drupal.org/project/commerce_vado/issues/3372715

## Description

when trying to enable media browser in ckeditor 5 I stumbled upon this error when triggering the entity browser in the ckeditor

<details>

<summary>error trace</summary>

```
"
An AJAX HTTP error occurred.
HTTP Result Code: 500
Debugging information follows.
Path: /entity-browser/modal/images?uuid=78f982d9-43ab-448c-8649-54d48b3734b1
StatusText: error
ResponseText: The website encountered an unexpected error. Try again later.InvalidArgumentException: Expected a scalar value as a 2nd argument to &quot;Symfony\Component\HttpFoundation\InputBag::get()&quot;, &quot;array&quot; given. in Symfony\Component\HttpFoundation\InputBag-&gt;get() (line 32 of /app/vendor/symfony/http-foundation/InputBag.php). {closure}(Array) (Line: 571)
wmcontent_preprocess_pager(Array, &#039;pager&#039;, Array)
call_user_func_array(&#039;wmcontent_preprocess_pager&#039;, Array) (Line: 261)
Drupal\Core\Theme\ThemeManager-&gt;render(&#039;pager&#039;, Array) (Line: 480)
Drupal\Core\Render\Renderer-&gt;doRender(Array) (Line: 493)
Drupal\Core\Render\Renderer-&gt;doRender(Array) (Line: 493)
Drupal\Core\Render\Renderer-&gt;doRender(Array) (Line: 493)
Drupal\Core\Render\Renderer-&gt;doRender(Array, 1) (Line: 240)
Drupal\Core\Render\Renderer-&gt;render(Array, 1) (Line: 153)
Drupal\Core\Render\Renderer-&gt;Drupal\Core\Render\{closure}() (Line: 627)
Drupal\Core\Render\Renderer-&gt;executeInRenderContext(Object, Object) (Line: 154)
Drupal\Core\Render\Renderer-&gt;renderRoot(Array) (Line: 22)
Drupal\Core\Render\MainContent\ModalRenderer-&gt;renderResponse(Array, Object, Object) (Line: 90)
Drupal\Core\EventSubscriber\MainContentViewSubscriber-&gt;onViewRenderArray(Object, &#039;kernel.view&#039;, Object)
call_user_func(Array, Object, &#039;kernel.view&#039;, Object) (Line: 111)
Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher-&gt;dispatch(Object, &#039;kernel.view&#039;) (Line: 186)
Symfony\Component\HttpKernel\HttpKernel-&gt;handleRaw(Object, 1) (Line: 76)
Symfony\Component\HttpKernel\HttpKernel-&gt;handle(Object, 1, 1) (Line: 58)
Drupal\Core\StackMiddleware\Session-&gt;handle(Object, 1, 1) (Line: 48)
Drupal\Core\StackMiddleware\KernelPreHandle-&gt;handle(Object, 1, 1) (Line: 24)
Drupal\wmcustom\Middleware\CachePermanentRedirectMiddleware-&gt;handle(Object, 1, 1) (Line: 22)
Drupal\wmcustom\Middleware\DisableCacheMiddleware-&gt;handle(Object, 1, 1) (Line: 48)
Drupal\wmcontroller\Http\Middleware\Cache-&gt;handle(Object, 1, 1) (Line: 48)
Drupal\wmsearch\Middleware\EarlyJson-&gt;handle(Object, 1, 1) (Line: 48)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware-&gt;handle(Object, 1, 1) (Line: 65)
Drupal\wmcustom\Middleware\SuffixWildcardMiddleware-&gt;handle(Object, 1, 1) (Line: 51)
Drupal\Core\StackMiddleware\NegotiationMiddleware-&gt;handle(Object, 1, 1) (Line: 36)
Drupal\Core\StackMiddleware\AjaxPageState-&gt;handle(Object, 1, 1) (Line: 39)
Drupal\wmcustom\Middleware\FtlMiddleware-&gt;handle(Object, 1, 1) (Line: 51)
Drupal\Core\StackMiddleware\StackedHttpKernel-&gt;handle(Object, 1, 1) (Line: 704)
Drupal\Core\DrupalKernel-&gt;handle(Object) (Line: 21)
"
```
</details>

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
