### PR TITLE
Fix Html::escape(): Argument #1 ($text) must be of type string, null given

### DIFF
--- a/src/Controller/SnapshotOverviewController.php
+++ b/src/Controller/SnapshotOverviewController.php
@@ -74,7 +74,7 @@ class SnapshotOverviewController implements ContainerInjectionInterface
             'Snapshots of %type %host',
             [
                 '%type' => $type,
-                '%host' => $host->label(),
+                '%host' => (string) $host->label(),
             ]
         );
     }
@@ -98,7 +98,7 @@ class SnapshotOverviewController implements ContainerInjectionInterface
             'Create new snapshot of %type %host',
             [
                 '%type' => $type,
-                '%host' => $host->label(),
+                '%host' => (string) $host->label(),
             ]
         );
     }
@@ -121,7 +121,7 @@ class SnapshotOverviewController implements ContainerInjectionInterface
             'Import existing snapshot to %type %host',
             [
                 '%type' => $type,
-                '%host' => $host->label(),
+                '%host' => (string) $host->label(),
             ]
         );
     }
@@ -221,10 +221,10 @@ class SnapshotOverviewController implements ContainerInjectionInterface
         return $this->t(
             'Export snapshot code of %snapshot_title (%snapshot_date)',
             [
-                '%snapshot_title' => $snapshot->label(),
+                '%snapshot_title' => (string) $snapshot->label(),
                 '%snapshot_date' => date('d/m/Y H:i', $snapshot->getCreatedTime()),
                 '%type' => $type,
-                '%host' => $host->label(),
+                '%host' => (string) $host->label(),
             ]
         );
     }
@@ -237,10 +237,10 @@ class SnapshotOverviewController implements ContainerInjectionInterface
         return $this->t(
             'Restore snapshot of %snapshot_date to %type %host',
             [
-                '%snapshot_title' => $snapshot->label(),
+                '%snapshot_title' => (string) $snapshot->label(),
                 '%snapshot_date' => date('d/m/Y H:i', $snapshot->getCreatedTime()),
                 '%type' => $type,
-                '%host' => $host->label(),
+                '%host' => (string) $host->label(),
             ]
         );
     }

--- a/src/Controller/WmContentChildController.php
+++ b/src/Controller/WmContentChildController.php
@@ -68,7 +68,7 @@ class WmContentChildController implements ContainerInjectionInterface
             'Add new %type to %host',
             [
                 '%type' => $type,
-                '%host' => $host->label(),
+                '%host' => (string) $host->label(),
             ]
         );
     }
@@ -82,7 +82,7 @@ class WmContentChildController implements ContainerInjectionInterface
                 '%container_label %name has been deleted.',
                 [
                     '%container_label' => $container->getLabel(),
-                    '%name' => $child->label(),
+                    '%name' => (string) $child->label(),
                 ]
             )
         );
@@ -118,7 +118,7 @@ class WmContentChildController implements ContainerInjectionInterface
             'Edit %type from %host',
             [
                 '%type' => $type,
-                '%host' => $host->label(),
+                '%host' => (string) $host->label(),
             ]
         );
     }

--- a/src/Form/Snapshot/SnapshotCreateForm.php
+++ b/src/Form/Snapshot/SnapshotCreateForm.php
@@ -95,12 +95,12 @@ class SnapshotCreateForm extends SnapshotFormBase
                 ],
                 'type' => [
                     'data' => [
-                        '#markup' => $block->type->entity->label(), // is bundle
+                        '#markup' => (string) $block->type->entity->label(), // is bundle
                     ],
                 ],
                 'label' => [
                     'data' => [
-                        '#markup' => $block->label(),
+                        '#markup' => (string) $block->label(),
                     ],
                 ],
             ];

--- a/src/Form/Snapshot/SnapshotRestoreForm.php
+++ b/src/Form/Snapshot/SnapshotRestoreForm.php
@@ -137,12 +137,12 @@ class SnapshotRestoreForm extends SnapshotFormBase
             $form['table']['#rows'][$i] = [
                 'type' => [
                     'data' => [
-                        '#markup' => $block->type->entity->label(), // is bundle
+                        '#markup' => (string) $block->type->entity->label(), // is bundle
                     ],
                 ],
                 'label' => [
                     'data' => [
-                        '#markup' => $block->label(),
+                        '#markup' => (string) $block->label(),
                     ],
                 ],
                 'errors' => [

--- a/src/Form/WmContentContainerDeleteForm.php
+++ b/src/Form/WmContentContainerDeleteForm.php
@@ -23,7 +23,7 @@ class WmContentContainerDeleteForm extends EntityConfirmFormBase
 
     public function getQuestion()
     {
-        return $this->t('Are you sure you want to delete the container %name?', ['%name' => $this->entity->label()]);
+        return $this->t('Are you sure you want to delete the container %name?', ['%name' => (string) $this->entity->label()]);
     }
 
     public function getCancelUrl()
@@ -39,8 +39,8 @@ class WmContentContainerDeleteForm extends EntityConfirmFormBase
     public function submitForm(array &$form, FormStateInterface $form_state)
     {
         $this->entity->delete();
-        $this->logger('wmcontent_container_entity')->notice('Container %name has been deleted.', ['%name' => $this->entity->label()]);
-        $this->messenger->addStatus($this->t('Container %name has been deleted.', ['%name' => $this->entity->label()]));
+        $this->logger('wmcontent_container_entity')->notice('Container %name has been deleted.', ['%name' => (string) $this->entity->label()]);
+        $this->messenger->addStatus($this->t('Container %name has been deleted.', ['%name' => (string) $this->entity->label()]));
         $form_state->setRedirectUrl($this->getCancelUrl());
     }
 }

--- a/src/Form/WmContentContainerForm.php
+++ b/src/Form/WmContentContainerForm.php
@@ -42,7 +42,7 @@ class WmContentContainerForm extends EntityForm
         $form['wrapper']['label'] = [
             '#type' => 'textfield',
             '#title' => $this->t('Container name'),
-            '#default_value' => $this->entity->label(),
+            '#default_value' => (string) $this->entity->label(),
             '#size' => 30,
             '#required' => true,
             '#maxlength' => 64,
@@ -181,7 +181,7 @@ class WmContentContainerForm extends EntityForm
     public function save(array $form, FormStateInterface $form_state)
     {
         // Prevent leading and trailing spaces.
-        $this->entity->set('label', trim($this->entity->label()));
+        $this->entity->set('label', trim((string) $this->entity->label()));
 
         $host_bundles = $this->entity->get('host_bundles');
         $host_bundles = array_filter($host_bundles);
@@ -204,14 +204,14 @@ class WmContentContainerForm extends EntityForm
         $this->messenger->addStatus($this->t(
             'Container %label has been %action.',
             [
-                '%label' => $this->entity->label(),
+                '%label' => (string) $this->entity->label(),
                 '%action' => $action,
             ]
         ));
         $this->logger('wmcontent')->notice(
             'Container %label has been %action.',
             [
-                '%label' => $this->entity->label(),
+                '%label' => (string) $this->entity->label(),
                 '%action' => $action,
             ]
         );

--- a/src/Form/WmContentMasterForm.php
+++ b/src/Form/WmContentMasterForm.php
@@ -58,8 +58,8 @@ class WmContentMasterForm implements FormInterface, ContainerInjectionInterface
         return $this->t(
             '%slug for %label',
             [
-                '%slug' => $container->getLabel(),
-                '%label' => $host->label(),
+                '%slug' => (string) $container->getLabel(),
+                '%label' => (string) $host->label(),
             ]
         );
     }
@@ -278,12 +278,12 @@ class WmContentMasterForm implements FormInterface, ContainerInjectionInterface
 
         $row['bundle'] = [
             '#type' => 'container',
-            '#markup' => $child->get('type')->entity->label(),
+            '#markup' => (string) $child->get('type')->entity->label(),
         ];
 
         $row['content'] = [
             '#type' => 'container',
-            '#markup' => $child->label(),
+            '#markup' => (string) $child->label(),
         ];
 
         if ($container->getShowSizeColumn()) {

--- a/src/Service/Snapshot/SnapshotListBuilder.php
+++ b/src/Service/Snapshot/SnapshotListBuilder.php
@@ -77,7 +77,7 @@ class SnapshotListBuilder extends EntityListBuilder implements SnapshotListBuild
         /** @var \Drupal\wmcontent\Entity\Snapshot $entity*/
         $row['name'] = [
             'data' => [
-                '#markup' => $entity->label(),
+                '#markup' => (string) $entity->label(),
             ],
         ];
         $row['created'] = [
@@ -88,7 +88,7 @@ class SnapshotListBuilder extends EntityListBuilder implements SnapshotListBuild
         $row['user'] = [
             'data' => [
                 '#markup' => $entity->getOwner()
-                    ? $entity->getOwner()->label()
+                    ? (string) $entity->getOwner()->label()
                     : '',
             ],
         ];
@@ -107,7 +107,7 @@ class SnapshotListBuilder extends EntityListBuilder implements SnapshotListBuild
 
             if ($host) {
                 $row['parent'] = Link::createFromRoute(
-                    $host->label(),
+                    (string) $host->label(),
                     'entity.wmcontent_snapshot.edit_form',
                     ['wmcontent_snapshot' => $entity->id()],
                 );

--- a/wmcontent.module
+++ b/wmcontent.module
@@ -29,7 +29,7 @@ function wmcontent_entity_extra_field_info(): array
         foreach ($container->getHostBundles() as $bundle) {
             $extra[$container->getHostEntityType()][$bundle]['display']['wmc_' . $container->id()] = [
                 'label' => 'WmContent: ' . $container->label(),
-                'description' => $container->label(),
+                'description' => (string) $container->label(),
                 'weight' => 0,
                 'visible' => true,
             ];
@@ -122,7 +122,7 @@ function wmcontent_entity_operation(EntityInterface $entity): array
     /** @var WmContentContainerInterface $container */
     foreach ($containers as $container) {
         $operations[$container->id()] = [
-            'title' => $container->label(),
+            'title' => (string) $container->label(),
             'url' => Url::fromRoute(
                 $routeName,
                 [


### PR DESCRIPTION
https://wieni.sentry.io/issues/4914418499/?project=4505759006261248&referrer=github_integration